### PR TITLE
[docs] swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
+    // spring-doc(swagger)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/farmsystem/homepage/global/common/HealthCheckApi.java
+++ b/src/main/java/org/farmsystem/homepage/global/common/HealthCheckApi.java
@@ -1,0 +1,44 @@
+package org.farmsystem.homepage.global.common;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Common API", description = "공통 API")
+public interface HealthCheckApi {
+
+    @Operation(
+            summary = "서버 상태 확인 API",
+            description = "FarmSysytem 서버 실행 상태를 확인하는 API입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "서버가 정상적으로 작동 중"),
+            @ApiResponse(responseCode = "404", description = "서버를 찾을 수 없음")
+    })
+    ResponseEntity<SuccessResponse<?>> FarmSysytemServer();
+
+    @Operation(
+            summary = "임시 토큰 발급 API",
+            description = "UserId로 임시 토큰을 발급받는 API입니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "토큰 발급 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SuccessResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    })
+    ResponseEntity<SuccessResponse<?>> getToken(
+            @Parameter(description = "userId, 임의 입력값", required = true, example = "1")
+            Long userId
+    );
+}

--- a/src/main/java/org/farmsystem/homepage/global/common/HealthCheckController.java
+++ b/src/main/java/org/farmsystem/homepage/global/common/HealthCheckController.java
@@ -2,10 +2,7 @@ package org.farmsystem.homepage.global.common;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.farmsystem.homepage.global.config.auth.jwt.JwtProvider;
 
 import java.util.HashMap;
@@ -13,17 +10,18 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
-public class HealthCheckApiController {
+public class HealthCheckController implements HealthCheckApi {
     private final JwtProvider jwtProvider;
 
-    @RequestMapping("/")
-    public String FarmSysytemServer() {
-        return "Hello! FarmSysytem Server!";
+    // 서버 상태 확인 API
+    @GetMapping("/")
+    public ResponseEntity<SuccessResponse<?>> FarmSysytemServer() {
+        return SuccessResponse.ok("Hello! FarmSysytem Server!");
     }
 
     // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
     @PostMapping("/token/{userId}")
-    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable(name = "userId") Long userId) {
+    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
         String accessToken = jwtProvider.getIssueToken(userId, true);
         String refreshToken = jwtProvider.getIssueToken(userId, false);
 

--- a/src/main/java/org/farmsystem/homepage/global/config/CorsConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig implements WebMvcConfigurer {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("*"); //임시로 모두 허용(프론트 주소 추가 필요)
+        config.addAllowedOrigin("http://localhost:5173"); //프론트 주소 추가 필요(배포,로컬)
         config.addAllowedHeader("*");
         config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package org.farmsystem.homepage.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("FarmSystem Homepage API Document")
+                .description("FarmSystem Homepage API 명세서입니다.")
+                .version("v1.0.0");
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .name("Authorization")
+                .type(SecurityScheme.Type.HTTP)
+                .in(HEADER)
+                .bearerFormat("JWT")
+                .scheme("Bearer");
+
+        Components components = new Components().addSecuritySchemes("token", securityScheme);
+
+        return new OpenAPI()
+                .info(info)
+                .components(components);
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -25,6 +25,12 @@ public class SecurityConfig {
 
     // 토큰 없이 접근 가능한 URL
     private static final String[] whiteList = {"/",
+            /* swagger */
+            "swagger/**",
+            "swagger-ui/**",
+            "v3/api-docs/**",
+
+            /* api */
             "token/**",
             };
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #3 
 
## 🌱 작업 사항
- 프론트 로컬 주소 cors추가
- swagger config 관련 세팅 추가
- swagger 예시 작성(health check API,임시 토큰 API)

## 🌱 참고 사항
- 노션에 yml 업데이트 했습니다. (스웨거 설정 추가)
- 스웨거는 `{BaseUrl}/swagger`경로로 접속 가능합니다.
 - 컨트롤러 로직이랑 문서화 코드 같이 쓰는 거보다 분리하는게 나을 거 같아서 명세 부분 인터페이스로 분리했는데 사용 예시는`/global/common/HealthCheckAPI` 랑 `/global/common/HealthCheckController` 확인해주시면 되겠습니다.