### PR TITLE
[feat] NEWS 기본 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // mysql
     implementation 'mysql:mysql-connector-java:8.0.32'

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
@@ -1,0 +1,52 @@
+package org.farmsystem.homepage.domain.news.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.domain.news.entity.News;
+import org.farmsystem.homepage.domain.news.service.NewsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/news")
+@RequiredArgsConstructor
+public class AdminNewsController {
+
+    private final NewsService newsService;
+
+    // 소식 작성
+    @PostMapping
+    public ResponseEntity<NewsResponseDTO> createNews(@RequestBody @Valid NewsRequestDTO request) {
+        News news = newsService.createNews(request);
+        NewsResponseDTO responseDto = new NewsResponseDTO(
+                news.getNewsId(),
+                news.getTitle(),
+                news.getContent()
+        );
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 소식 수정
+    @PutMapping("/{newsId}")
+    public ResponseEntity<NewsResponseDTO> updateNews(
+            @PathVariable("newsId") Long newsId, // 명시적으로 변수명 지정
+            @RequestBody @Valid NewsRequestDTO request
+    ) {
+        News updatedNews = newsService.updateNews(newsId, request);
+        NewsResponseDTO responseDto = new NewsResponseDTO(
+                updatedNews.getNewsId(),
+                updatedNews.getTitle(),
+                updatedNews.getContent()
+        );
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 소식 삭제
+    @DeleteMapping("/{newsId}")
+    public ResponseEntity<Void> deleteNews(@PathVariable("newsId") Long newsId) { // 명확한 매핑
+        newsService.deleteNews(newsId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
@@ -6,6 +6,7 @@ import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
 import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
 import org.farmsystem.homepage.domain.news.entity.News;
 import org.farmsystem.homepage.domain.news.service.NewsService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,36 +17,24 @@ public class AdminNewsController {
 
     private final NewsService newsService;
 
-    // 소식 작성
     @PostMapping
-    public ResponseEntity<NewsResponseDTO> createNews(@RequestBody @Valid NewsRequestDTO request) {
+    public ResponseEntity<SuccessResponse<?>> createNews(@RequestBody @Valid NewsRequestDTO request) {
         News news = newsService.createNews(request);
-        NewsResponseDTO responseDto = new NewsResponseDTO(
-                news.getNewsId(),
-                news.getTitle(),
-                news.getContent()
-        );
-        return ResponseEntity.ok(responseDto);
+        NewsResponseDTO responseDto = new NewsResponseDTO(news.getNewsId(), news.getTitle(), news.getContent());
+        return SuccessResponse.created(responseDto);
     }
 
-    // 소식 수정
     @PutMapping("/{newsId}")
-    public ResponseEntity<NewsResponseDTO> updateNews(
-            @PathVariable("newsId") Long newsId, // 명시적으로 변수명 지정
-            @RequestBody @Valid NewsRequestDTO request
-    ) {
+    public ResponseEntity<SuccessResponse<?>> updateNews(
+            @PathVariable("newsId") Long newsId,
+            @RequestBody @Valid NewsRequestDTO request) {
         News updatedNews = newsService.updateNews(newsId, request);
-        NewsResponseDTO responseDto = new NewsResponseDTO(
-                updatedNews.getNewsId(),
-                updatedNews.getTitle(),
-                updatedNews.getContent()
-        );
-        return ResponseEntity.ok(responseDto);
+        NewsResponseDTO responseDto = new NewsResponseDTO(updatedNews.getNewsId(), updatedNews.getTitle(), updatedNews.getContent());
+        return SuccessResponse.ok(responseDto);
     }
 
-    // 소식 삭제
     @DeleteMapping("/{newsId}")
-    public ResponseEntity<Void> deleteNews(@PathVariable("newsId") Long newsId) { // 명확한 매핑
+    public ResponseEntity<Void> deleteNews(@PathVariable("newsId") Long newsId) {
         newsService.deleteNews(newsId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
@@ -1,0 +1,43 @@
+package org.farmsystem.homepage.domain.news.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.domain.news.entity.News;
+import org.farmsystem.homepage.domain.news.service.NewsService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+public class NewsController {
+
+    private final NewsService newsService;
+
+    // 모든 소식 조회
+    @GetMapping
+    public ResponseEntity<List<NewsResponseDTO>> getAllNews() {
+        List<News> newsList = newsService.getAllNews();
+        List<NewsResponseDTO> dtoList = newsList.stream()
+                .map(news -> new NewsResponseDTO(
+                        news.getNewsId(),
+                        news.getTitle(),
+                        news.getContent()))
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(dtoList);
+    }
+
+    // 소식 단건 조회
+    @GetMapping("/{newsId}")
+    public ResponseEntity<NewsResponseDTO> getNewsById(@PathVariable("newsId") Long newsId) {
+        News news = newsService.getNewsById(newsId);
+        NewsResponseDTO dto = new NewsResponseDTO(
+                news.getNewsId(),
+                news.getTitle(),
+                news.getContent());
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
 import org.farmsystem.homepage.domain.news.entity.News;
 import org.farmsystem.homepage.domain.news.service.NewsService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,9 +18,8 @@ public class NewsController {
 
     private final NewsService newsService;
 
-    // 모든 소식 조회
     @GetMapping
-    public ResponseEntity<List<NewsResponseDTO>> getAllNews() {
+    public ResponseEntity<SuccessResponse<?>> getAllNews() {
         List<News> newsList = newsService.getAllNews();
         List<NewsResponseDTO> dtoList = newsList.stream()
                 .map(news -> new NewsResponseDTO(
@@ -27,17 +27,13 @@ public class NewsController {
                         news.getTitle(),
                         news.getContent()))
                 .collect(Collectors.toList());
-        return ResponseEntity.ok(dtoList);
+        return SuccessResponse.ok(dtoList);
     }
 
-    // 소식 단건 조회
     @GetMapping("/{newsId}")
-    public ResponseEntity<NewsResponseDTO> getNewsById(@PathVariable("newsId") Long newsId) {
+    public ResponseEntity<SuccessResponse<?>> getNewsById(@PathVariable("newsId") Long newsId) {
         News news = newsService.getNewsById(newsId);
-        NewsResponseDTO dto = new NewsResponseDTO(
-                news.getNewsId(),
-                news.getTitle(),
-                news.getContent());
-        return ResponseEntity.ok(dto);
+        NewsResponseDTO responseDto = new NewsResponseDTO(news.getNewsId(), news.getTitle(), news.getContent());
+        return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
@@ -1,0 +1,4 @@
+package org.farmsystem.homepage.domain.news.dto.request;
+
+
+public record NewsRequestDTO(String title, String content) { }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsResponseDTO.java
@@ -1,0 +1,5 @@
+package org.farmsystem.homepage.domain.news.dto.response;
+
+
+public record NewsResponseDTO(Long newsId, String title, String content) { }
+

--- a/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
@@ -1,0 +1,47 @@
+package org.farmsystem.homepage.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "news")
+@NoArgsConstructor
+public class News {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long newsId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public News(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public void updateTitleAndContent(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/repository/NewsRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/repository/NewsRepository.java
@@ -1,0 +1,9 @@
+package org.farmsystem.homepage.domain.news.repository;
+
+import org.farmsystem.homepage.domain.news.entity.News;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NewsRepository extends JpaRepository<News, Long> {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
@@ -1,0 +1,50 @@
+package org.farmsystem.homepage.domain.news.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
+import org.farmsystem.homepage.domain.news.entity.News;
+import org.farmsystem.homepage.domain.news.repository.NewsRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+
+    public List<News> getAllNews() {
+        return newsRepository.findAll();
+    }
+
+    public News getNewsById(Long newsId) {
+        return newsRepository.findById(newsId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 소식을 찾을 수 없습니다. ID: " + newsId));
+    }
+
+    @Transactional
+    public News createNews(NewsRequestDTO request) {
+        News news = News.builder()
+                .title(request.title())
+                .content(request.content())
+                .build();
+        return newsRepository.save(news);
+    }
+
+    @Transactional
+    public News updateNews(Long newsId, NewsRequestDTO request) {
+        News news = getNewsById(newsId);
+        news.updateTitleAndContent(request.title(), request.content());
+        return news;
+    }
+
+    @Transactional
+    public void deleteNews(Long newsId) {
+        if (!newsRepository.existsById(newsId)) {
+            throw new IllegalArgumentException("존재하지 않는 소식입니다. ID: " + newsId);
+        }
+        newsRepository.deleteById(newsId);
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
 import org.farmsystem.homepage.domain.news.entity.News;
 import org.farmsystem.homepage.domain.news.repository.NewsRepository;
+import org.farmsystem.homepage.global.error.ErrorCode;
+import org.farmsystem.homepage.global.error.exception.BusinessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +23,7 @@ public class NewsService {
 
     public News getNewsById(Long newsId) {
         return newsRepository.findById(newsId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 소식을 찾을 수 없습니다. ID: " + newsId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
     }
 
     @Transactional
@@ -43,7 +45,7 @@ public class NewsService {
     @Transactional
     public void deleteNews(Long newsId) {
         if (!newsRepository.existsById(newsId)) {
-            throw new IllegalArgumentException("존재하지 않는 소식입니다. ID: " + newsId);
+            throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND);
         }
         newsRepository.deleteById(newsId);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #7 
 
## 🌱 작업 사항
- news 엔티티, 레포지토리 생성
- news 일반 사용자용 컨트롤러, 관리자용 컨트롤러 생성
- news 기본 기능 개발

## 🌱 참고 사항
- 이후에 관리자용 컨트롤러에 권한 제어 추가 필요함.
