### PR TITLE
[refactor] news BaseTimeEntity, 에러코드, swagger-ui

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsApi.java
@@ -1,0 +1,59 @@
+package org.farmsystem.homepage.domain.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+
+@Tag(name = "[관리자] 소식 API", description = "관리자용 소식 관련 API")
+public interface AdminNewsApi {
+
+    @Operation(summary = "[관리자] 소식 생성", description = "새로운 소식을 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = NewsResponseDTO.class)
+                    )
+            )
+    })
+    @PostMapping("/api/admin/news")
+    ResponseEntity<SuccessResponse<?>> createNews(@RequestBody @Valid NewsRequestDTO request);
+
+    @Operation(summary = "[관리자] 소식 수정", description = "기존 소식 제목과 내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = NewsResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 소식 ID")
+    })
+    @PutMapping("/api/admin/news/{newsId}")
+    ResponseEntity<SuccessResponse<?>> updateNews(
+            @PathVariable("newsId") Long newsId,
+            @RequestBody @Valid NewsRequestDTO request);
+
+    @Operation(summary = "[관리자] 소식 삭제", description = "ID를 통해 특정 소식을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 소식 ID")
+    })
+    @DeleteMapping("/api/admin/news/{newsId}")
+    ResponseEntity<Void> deleteNews(@PathVariable("newsId") Long newsId);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/admin/news")
 @RequiredArgsConstructor
-public class AdminNewsController {
+public class AdminNewsController implements AdminNewsApi{
 
     private final NewsService newsService;
 

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsApi.java
@@ -1,0 +1,49 @@
+package org.farmsystem.homepage.domain.news.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@Tag(name = "소식 API", description = "소식 관련 API")
+@RequestMapping("/api/news")
+public interface NewsApi {
+
+    @Operation(summary = "전체 소식 조회", description = "등록된 모든 소식을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = NewsResponseDTO.class))
+                    )
+            )
+    })
+    @GetMapping
+    ResponseEntity<SuccessResponse<?>> getAllNews();
+
+    @Operation(summary = "단일 소식 조회", description = "ID를 통해 특정 소식을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = NewsResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 소식 ID")
+    })
+    @GetMapping("/{newsId}")
+    ResponseEntity<SuccessResponse<?>> getNewsById(@PathVariable("newsId") Long newsId);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/news")
 @RequiredArgsConstructor
-public class NewsController {
+public class NewsController implements NewsApi{
 
     private final NewsService newsService;
 

--- a/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.farmsystem.homepage.global.common.BaseTimeEntity;
 
 import java.time.LocalDateTime;
 
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "news")
 @NoArgsConstructor
-public class News {
+public class News extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,16 +23,6 @@ public class News {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt = LocalDateTime.now();
-
-    private LocalDateTime updatedAt = LocalDateTime.now();
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = LocalDateTime.now();
-    }
 
     @Builder
     public News(String title, String content) {

--- a/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
@@ -23,7 +23,7 @@ public class NewsService {
 
     public News getNewsById(Long newsId) {
         return newsRepository.findById(newsId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEWS_NOT_FOUND));
     }
 
     @Transactional
@@ -45,7 +45,7 @@ public class NewsService {
     @Transactional
     public void deleteNews(Long newsId) {
         if (!newsRepository.existsById(newsId)) {
-            throw new BusinessException(ErrorCode.ENTITY_NOT_FOUND);
+            throw new BusinessException(ErrorCode.NEWS_NOT_FOUND);
         }
         newsRepository.deleteById(newsId);
     }

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -46,7 +46,12 @@ public enum ErrorCode {
     /**
      * 500 Internal Server Error
      */
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    /**
+     * news 관련 에러 처리
+     */
+    NEWS_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 뉴스를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #7, #16 
 
## 🌱 작업 사항
- news 엔티티에 BaseTimeEntity 적용
- ErrorCode에 news 용 에러코드 추가
- NewsService에 news용 에러코드 적용
- news에 swagger-ui 적용

## 🌱 참고 사항
### 🤔 [고민하고 있는 점]
### 1. `ErrorCode` 분리 방안
- `ErrorCode`가 많아지면 헷갈릴 것 같아서 news 섹션을 따로 나누고 에러 코드를 추가했는데, 코드별로 합칠까요, 기능별로 합칠까요? 

### 2. swagger-ui와 컨트롤러 반환 타입 관련
a. 기존 컨트롤러 메서드 반환 타입이 `ResponseEntity<SuccessResponse<?>>`로 되어있습니다. 
b. swagger 관련 인터페이스(`NewsApi`, `AdminNewsApi`)에서는 명시적 제네릭 타입으로 적용 (`ResponseEntity<SuccessResponse<List<NewsResponseDTO>>>`)하고 싶었으나,
c. 시그니처 불일치로 컴파일 오류가 났습니다. 
d. `SuccessResponse` 클래스가 `ResponseEntity<SuccessResponse<?>>`를 반환하고 있어 타입 추론하도록 하기 어려웠습니다.
e. 그래도 `SuccessResponse`를 유지하고 싶었고, 컨트롤러는 그대로 유지하게 되었습니다. 
f. 차선책으로 swagger 인터페이스만 수정했습니다. -> 인터페이스도 와일드카드 사용하도록 유지하되, `@ApiResponse의 @Schema(implementation = ...)`를 통해 실제 반환 DTO를 Swagger 문서에서 설명하는 방식으로 했는데
g. 이렇게 해도 될까요?
