### PR TITLE
[feat] User & Oauth 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-    // mysql
+    //mysql
     implementation 'mysql:mysql-connector-java:8.0.32'
 
     //lombok
@@ -40,16 +40,19 @@ dependencies {
     //spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // jwt
+    //jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-    // spring-doc(swagger)
+    //spring-doc(swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 
     //aws
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     // spring-doc(swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
+
+    //aws
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.541'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/PassedApply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/PassedApply.java
@@ -1,0 +1,22 @@
+package org.farmsystem.homepage.domain.apply.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "passed_apply")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PassedApply {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long passedApplyId;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String studentNumber;
+}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/PassedApplyRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/PassedApplyRepository.java
@@ -1,0 +1,10 @@
+package org.farmsystem.homepage.domain.apply.repository;
+
+import org.farmsystem.homepage.domain.apply.entity.PassedApply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PassedApplyRepository extends JpaRepository<PassedApply, Long> {
+    Optional<PassedApply> findByStudentNumber(String studentNumber);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/OauthController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/OauthController.java
@@ -1,0 +1,29 @@
+package org.farmsystem.homepage.domain.user.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.homepage.domain.user.service.OauthService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@RestController
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    // 소셜 로그인
+    @PostMapping("/login")
+    ResponseEntity<SuccessResponse<?>> socialLogin(@RequestBody UserLoginRequestDTO userLoginRequest) {
+        UserTokenResponseDTO userToken = oauthService.socialLogin(userLoginRequest);
+        return SuccessResponse.ok(userToken);
+    }
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/OauthController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/OauthController.java
@@ -1,16 +1,17 @@
 package org.farmsystem.homepage.domain.user.controller;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.request.UserTokenRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.service.OauthService;
+import org.farmsystem.homepage.domain.user.service.TokenService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -18,11 +19,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class OauthController {
 
     private final OauthService oauthService;
+    private final TokenService tokenService;
+
+    // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
+    @PostMapping("/token/{userId}")
+    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
+        UserTokenResponseDTO userToken= tokenService.issueTempToken(userId);
+        return SuccessResponse.ok(userToken);
+    }
 
     // 소셜 로그인
     @PostMapping("/login")
     ResponseEntity<SuccessResponse<?>> socialLogin(@RequestBody UserLoginRequestDTO userLoginRequest) {
         UserTokenResponseDTO userToken = oauthService.socialLogin(userLoginRequest);
+        return SuccessResponse.ok(userToken);
+    }
+
+    // 로그아웃
+    @PostMapping("/logout")
+    ResponseEntity<SuccessResponse<?>> logout(@AuthenticationPrincipal Long userId) {
+        tokenService.logout(userId);
+        return SuccessResponse.ok(null);
+    }
+
+    // 리프레쉬 토큰 재발급
+    @PostMapping("/reissue")
+    public ResponseEntity<SuccessResponse<?>> reissueToken(@RequestBody UserTokenRequestDTO uerTokenRequest) throws JsonProcessingException {
+        UserTokenResponseDTO userToken = tokenService.reissue(uerTokenRequest);
         return SuccessResponse.ok(userToken);
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -2,8 +2,10 @@ package org.farmsystem.homepage.domain.user.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.user.dto.request.UserInfoUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserInfoUpdateResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
 import org.farmsystem.homepage.domain.user.service.UserService;
@@ -11,6 +13,9 @@ import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/user")
@@ -21,22 +26,31 @@ public class UserController {
     // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
     @PostMapping("/token/{userId}")
     public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
-        UserTokenResponseDTO userTokenResponse = userService.issueTempToken(userId);
-        return SuccessResponse.ok(userTokenResponse);
+        UserTokenResponseDTO userToken= userService.issueTempToken(userId);
+        return SuccessResponse.ok(userToken);
     }
 
     // 사용자 회원 인증 API
     @PostMapping("/verify")
     public ResponseEntity<SuccessResponse<?>> verifyUser(@RequestBody UserVerifyRequestDTO userVerifyRequest) {
-        UserVerifyResponseDTO userVerifyResponse = userService.verifyUser(userVerifyRequest);
-        return SuccessResponse.ok(userVerifyResponse);
+        UserVerifyResponseDTO userVerify = userService.verifyUser(userVerifyRequest);
+        return SuccessResponse.ok(userVerify);
     }
 
     // 마이페이지 사용자 정보 조회 API
     @GetMapping("/mypage")
     public ResponseEntity<SuccessResponse<?>> getUserInfo(@AuthenticationPrincipal Long userId) {
-        UserInfoResponseDTO userInfoResponse = userService.getUserInfo(userId);
-        return SuccessResponse.ok(userInfoResponse);
+        UserInfoResponseDTO userInfo = userService.getUserInfo(userId);
+        return SuccessResponse.ok(userInfo);
     }
 
+    // 사용자 정보 수정 API
+    @PutMapping("/mypage")
+    public ResponseEntity<SuccessResponse<?>> updateUserInfo( @AuthenticationPrincipal Long userId,
+                                                              @RequestPart(required = false) String phoneNumber,
+                                                              @RequestPart(required = false) MultipartFile profileImage) throws IOException {
+        UserInfoUpdateRequestDTO userInfoRequest = new UserInfoUpdateRequestDTO(phoneNumber, profileImage);
+        UserInfoUpdateResponseDTO userInfoUpdate = userService.updateUserInfo(userId, userInfoRequest);
+        return SuccessResponse.ok(userInfoUpdate);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -47,9 +47,7 @@ public class UserController {
     // 사용자 정보 수정 API
     @PutMapping("/mypage")
     public ResponseEntity<SuccessResponse<?>> updateUserInfo( @AuthenticationPrincipal Long userId,
-                                                              @RequestPart(required = false) String phoneNumber,
-                                                              @RequestPart(required = false) MultipartFile profileImage) throws IOException {
-        UserInfoUpdateRequestDTO userInfoRequest = new UserInfoUpdateRequestDTO(phoneNumber, profileImage);
+                                                              @ModelAttribute UserInfoUpdateRequestDTO userInfoRequest) throws IOException {
         UserInfoUpdateResponseDTO userInfoUpdate = userService.updateUserInfo(userId, userInfoRequest);
         return SuccessResponse.ok(userInfoUpdate);
     }

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -1,0 +1,34 @@
+package org.farmsystem.homepage.domain.user.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.user.service.UserService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
+    @PostMapping("/token/{userId}")
+    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
+        UserTokenResponseDTO userTokenResponse = userService.issueTempToken(userId);
+        return SuccessResponse.ok(userTokenResponse);
+    }
+
+    // 사용자 인증 API
+    @PostMapping("/verify")
+    public ResponseEntity<SuccessResponse<?>> verifyUser(@RequestBody UserVerifyRequestDTO userVerifyRequest) {
+        UserVerifyResponseDTO userVerifyResponse = userService.verifyUser(userVerifyRequest);
+        return SuccessResponse.ok(userVerifyResponse);
+    }
+
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -23,13 +23,6 @@ import java.io.IOException;
 public class UserController {
     private final UserService userService;
 
-    // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
-    @PostMapping("/token/{userId}")
-    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
-        UserTokenResponseDTO userToken= userService.issueTempToken(userId);
-        return SuccessResponse.ok(userToken);
-    }
-
     // 사용자 회원 인증 API
     @PostMapping("/verify")
     public ResponseEntity<SuccessResponse<?>> verifyUser(@RequestBody UserVerifyRequestDTO userVerifyRequest) {

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -3,11 +3,13 @@ package org.farmsystem.homepage.domain.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
 import org.farmsystem.homepage.domain.user.service.UserService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -23,12 +25,18 @@ public class UserController {
         return SuccessResponse.ok(userTokenResponse);
     }
 
-    // 사용자 인증 API
+    // 사용자 회원 인증 API
     @PostMapping("/verify")
     public ResponseEntity<SuccessResponse<?>> verifyUser(@RequestBody UserVerifyRequestDTO userVerifyRequest) {
         UserVerifyResponseDTO userVerifyResponse = userService.verifyUser(userVerifyRequest);
         return SuccessResponse.ok(userVerifyResponse);
     }
 
+    // 마이페이지 사용자 정보 조회 API
+    @GetMapping("/mypage")
+    public ResponseEntity<SuccessResponse<?>> getUserInfo(@AuthenticationPrincipal Long userId) {
+        UserInfoResponseDTO userInfoResponse = userService.getUserInfo(userId);
+        return SuccessResponse.ok(userInfoResponse);
+    }
 
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserInfoUpdateRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserInfoUpdateRequestDTO.java
@@ -1,0 +1,9 @@
+package org.farmsystem.homepage.domain.user.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UserInfoUpdateRequestDTO(
+        String phoneNumber,
+        MultipartFile profileImage
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserLoginRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserLoginRequestDTO.java
@@ -1,0 +1,12 @@
+package org.farmsystem.homepage.domain.user.dto.request;
+
+import org.farmsystem.homepage.domain.user.entity.SocialType;
+
+public record UserLoginRequestDTO(
+        String code,
+        SocialType socialType,
+        String studentNumber,
+        String name
+
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserTokenRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserTokenRequestDTO.java
@@ -1,0 +1,7 @@
+package org.farmsystem.homepage.domain.user.dto.request;
+
+public record UserTokenRequestDTO(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserVerifyRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/request/UserVerifyRequestDTO.java
@@ -1,0 +1,6 @@
+package org.farmsystem.homepage.domain.user.dto.request;
+
+public record UserVerifyRequestDTO(
+        String studentNumber
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserInfoResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserInfoResponseDTO.java
@@ -1,0 +1,31 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import org.farmsystem.homepage.domain.user.entity.Track;
+import org.farmsystem.homepage.domain.user.entity.User;
+
+public record UserInfoResponseDTO(
+        String name,
+        String studentNumber,
+        String profileImageUrl,
+        String phoneNumber,
+        String email,
+        Track track,
+        Integer generation,
+        Integer currentSeed,
+        Integer totalSeed
+) {
+    public static UserInfoResponseDTO from(User user) {
+        return new UserInfoResponseDTO(
+                user.getName(),
+                user.getStudentNumber(),
+                user.getProfileImageUrl(),
+                user.getPhoneNumber(),
+                user.getEmail(),
+                user.getTrack(),
+                user.getGeneration(),
+                user.getCurrentSeed(),
+                user.getTotalSeed()
+        );
+    }
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserInfoUpdateResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserInfoUpdateResponseDTO.java
@@ -1,0 +1,12 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import org.farmsystem.homepage.domain.user.entity.User;
+
+public record UserInfoUpdateResponseDTO(
+        String phoneNumber,
+        String profileImageUrl
+) {
+    public static UserInfoUpdateResponseDTO from(User user) {
+        return new UserInfoUpdateResponseDTO(user.getPhoneNumber(), user.getProfileImageUrl());
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserTokenResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserTokenResponseDTO.java
@@ -3,4 +3,8 @@ package org.farmsystem.homepage.domain.user.dto.response;
 public record UserTokenResponseDTO(
         String accessToken,
         String refreshToken
-) { }
+) {
+    public static UserTokenResponseDTO of(String accessToken, String refreshToken) {
+        return new UserTokenResponseDTO(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserTokenResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserTokenResponseDTO.java
@@ -1,0 +1,6 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+public record UserTokenResponseDTO(
+        String accessToken,
+        String refreshToken
+) { }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
@@ -3,6 +3,8 @@ package org.farmsystem.homepage.domain.user.dto.response;
 public record UserVerifyResponseDTO(
         Boolean isVerified,
         String name
-
 ) {
+    public static UserVerifyResponseDTO from(Boolean isVerified, String name) {
+        return new UserVerifyResponseDTO(isVerified, name);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
@@ -1,0 +1,8 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+public record UserVerifyResponseDTO(
+        Boolean isVerified,
+        String name
+
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserVerifyResponseDTO.java
@@ -1,10 +1,19 @@
 package org.farmsystem.homepage.domain.user.dto.response;
 
+import org.farmsystem.homepage.domain.apply.entity.PassedApply;
+import org.farmsystem.homepage.domain.user.entity.User;
+
 public record UserVerifyResponseDTO(
         Boolean isVerified,
+        String studentNumber,
         String name
+
 ) {
-    public static UserVerifyResponseDTO from(Boolean isVerified, String name) {
-        return new UserVerifyResponseDTO(isVerified, name);
+    public static UserVerifyResponseDTO from(Boolean isVerified, PassedApply verifiedUser) {
+        return new UserVerifyResponseDTO(
+                isVerified,
+                verifiedUser.getStudentNumber(),
+                verifiedUser.getName()
+        );
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/SocialType.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/SocialType.java
@@ -1,0 +1,5 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+public enum SocialType {
+    KAKAO, GOOGLE
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/Track.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/Track.java
@@ -1,0 +1,5 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+public enum Track {
+    UNION, GAMING_VIDEO, SECURITY_WEB, AI, IOT_ROBOTICS, BIGDATA
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/TrackHistory.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/TrackHistory.java
@@ -1,0 +1,27 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Table(name = "track_history")
+@Entity
+public class TrackHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long trackHistoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Track track;
+
+    @Column(nullable = false)
+    private int generation;
+
+
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -3,6 +3,7 @@ package org.farmsystem.homepage.domain.user.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.farmsystem.homepage.global.common.BaseTimeEntity;
 import org.hibernate.annotations.ColumnDefault;
 
@@ -24,9 +25,11 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
+    @Setter
     @Column(length = 100)
     private String profileImageUrl;
 
+    @Setter
     @Column(length = 20)
     private String phoneNumber;
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -1,0 +1,49 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
+
+
+@NoArgsConstructor
+@Table(name = "user")
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, length = 10)
+    private String name;
+
+    @Column(nullable = false, length = 20)
+    private String studentNumber;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 500)
+    private String profileImageUrl;
+
+    @ColumnDefault("false")
+    private boolean isDeleted;
+
+    @ColumnDefault("0")
+    private int currentSeed;
+
+    @ColumnDefault("0")
+    private int totalSeed;
+
+    @OneToMany(mappedBy = "user")
+    private List<TrackHistory> trackHistories;
+
+
+
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -1,6 +1,7 @@
 package org.farmsystem.homepage.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -26,11 +27,11 @@ public class User extends BaseTimeEntity {
     private String studentNumber;
 
     @Setter
-    @Column(length = 100)
+    @Column(length = 500)
     private String profileImageUrl;
 
     @Setter
-    @Column(length = 20)
+    @Column(nullable = true, length = 20)
     private String phoneNumber;
 
     @Column(length = 100)
@@ -41,6 +42,8 @@ public class User extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Track track;
+
+    @Column(nullable = true)
     private int generation;
 
     @ColumnDefault("false")
@@ -54,4 +57,12 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "user")
     private List<TrackHistory> trackHistories;
+
+    @Builder
+    public User(String profileImageUrl,String name, String studentNumber, SocialType socialType) {
+        this.profileImageUrl = profileImageUrl;
+        this.name = name;
+        this.studentNumber = studentNumber;
+        this.socialType = socialType;
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -22,14 +22,11 @@ public class User {
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
+    @Column(length = 500)
+    private String profileImageUrl;
+
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
-
-    @Column(nullable = false, length = 100)
-    private String email;
-
-    @Column(nullable = false, length = 500)
-    private String profileImageUrl;
 
     @ColumnDefault("false")
     private boolean isDeleted;
@@ -42,8 +39,4 @@ public class User {
 
     @OneToMany(mappedBy = "user")
     private List<TrackHistory> trackHistories;
-
-
-
-
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -1,16 +1,18 @@
 package org.farmsystem.homepage.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.farmsystem.homepage.global.common.BaseTimeEntity;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.List;
 
-
+@Getter
 @NoArgsConstructor
 @Table(name = "user")
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,11 +24,21 @@ public class User {
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
-    @Column(length = 500)
+    @Column(length = 100)
     private String profileImageUrl;
+
+    @Column(length = 20)
+    private String phoneNumber;
+
+    @Column(length = 100)
+    private String email;
 
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
+
+    @Enumerated(EnumType.STRING)
+    private Track track;
+    private int generation;
 
     @ColumnDefault("false")
     private boolean isDeleted;

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -1,0 +1,6 @@
+package org.farmsystem.homepage.domain.user.repository;
+
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long>{}

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -3,4 +3,6 @@ package org.farmsystem.homepage.domain.user.repository;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User,Long>{}
+public interface UserRepository extends JpaRepository<User,Long>{
+    User findByStudentNumber(String studentNumber);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/OauthService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/OauthService.java
@@ -20,7 +20,8 @@ public class OauthService {
     private final OauthTokenProvider oauthTokenProvider;
     private final OauthUserResourceProvider oauthUserResourceProvider;
     private final UserRepository userRepository;
-    private final UserService userService;
+    private final TokenService tokenService;
+
 
     @Transactional
     public UserTokenResponseDTO socialLogin(UserLoginRequestDTO userLoginRequest) {
@@ -42,9 +43,7 @@ public class OauthService {
             Long userId = saveOrUpdateUser(imageUrl, userLoginRequest);
 
             // JWT 토큰 발급
-            String refreshToken = userService.issueNewRefreshToken(userId);
-            String accessToken = userService.issueNewAccessToken(userId);
-            return UserTokenResponseDTO.of(accessToken, refreshToken);
+            return tokenService.issueToken(userId);
 
         } catch (Exception e) {
             throw new BusinessException(INTERNAL_SERVER_ERROR);
@@ -56,8 +55,7 @@ public class OauthService {
 
         if (existingUser != null) {
             return existingUser.getUserId();
-        }
-        else {
+        } else {
             User user = User.builder()
                     .profileImageUrl(imageUrl)
                     .name(userLoginRequest.name())

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/OauthService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/OauthService.java
@@ -1,0 +1,71 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.homepage.domain.user.entity.SocialType;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.global.error.exception.BusinessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.INTERNAL_SERVER_ERROR;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final OauthTokenProvider oauthTokenProvider;
+    private final OauthUserResourceProvider oauthUserResourceProvider;
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    @Transactional
+    public UserTokenResponseDTO socialLogin(UserLoginRequestDTO userLoginRequest) {
+        try {
+            SocialType socialType = userLoginRequest.socialType();
+
+            // OAuth 토큰 가져오기
+            String oauthToken = oauthTokenProvider.getOauthToken(userLoginRequest.code(), socialType);
+
+            // 사용자 정보 가져오기
+            JsonNode userResource = oauthUserResourceProvider.getUserResource(oauthToken, socialType);
+
+            // 사용자 정보 처리
+            String imageUrl = socialType.equals(SocialType.GOOGLE)
+                    ? userResource.path("picture").asText()
+                    : userResource.path("kakao_account").path("profile").path("profile_image_url").asText();
+
+            // 사용자 저장
+            Long userId = saveOrUpdateUser(imageUrl, userLoginRequest);
+
+            // JWT 토큰 발급
+            String refreshToken = userService.issueNewRefreshToken(userId);
+            String accessToken = userService.issueNewAccessToken(userId);
+            return UserTokenResponseDTO.of(accessToken, refreshToken);
+
+        } catch (Exception e) {
+            throw new BusinessException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public Long saveOrUpdateUser(String imageUrl, UserLoginRequestDTO userLoginRequest) {
+        User existingUser = userRepository.findByStudentNumber(userLoginRequest.studentNumber());
+
+        if (existingUser != null) {
+            return existingUser.getUserId();
+        }
+        else {
+            User user = User.builder()
+                    .profileImageUrl(imageUrl)
+                    .name(userLoginRequest.name())
+                    .studentNumber(userLoginRequest.studentNumber())
+                    .socialType(userLoginRequest.socialType())
+                    .build();
+            User savedUser = userRepository.save(user);
+            return savedUser.getUserId();
+        }
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/OauthTokenProvider.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/OauthTokenProvider.java
@@ -1,0 +1,72 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import org.farmsystem.homepage.domain.user.entity.SocialType;
+import org.farmsystem.homepage.global.error.exception.BusinessException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.OAUTH_TOKEN_REQUEST_FAILED;
+
+// OAuth 토큰 요청 클래스
+@Service
+public class OauthTokenProvider {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String googleRedirectUri;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String kakaoClientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    public String getOauthToken(String code, SocialType socialType) {
+        try {
+            String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8); //구글 로그인 인가코드 인코딩 관련 오류 방지 (%2F -> /)
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
+            requestBody.add("code", decodedCode);
+            requestBody.add("client_id", socialType.equals(SocialType.GOOGLE) ? googleClientId : kakaoClientId);
+            requestBody.add("client_secret", socialType.equals(SocialType.GOOGLE) ? googleClientSecret : kakaoClientSecret);
+            requestBody.add("redirect_uri", socialType.equals(SocialType.GOOGLE) ? googleRedirectUri : kakaoRedirectUri);
+            requestBody.add("grant_type", "authorization_code");
+
+            HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    socialType.equals(SocialType.GOOGLE) ? "https://oauth2.googleapis.com/token" : "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST, requestEntity, Map.class);
+
+            Map<String, Object> responseBody = response.getBody();
+            if (responseBody != null && responseBody.containsKey("access_token")) {
+                return (String) responseBody.get("access_token");
+            } else {
+                throw new BusinessException(OAUTH_TOKEN_REQUEST_FAILED);
+            }
+        } catch (Exception e) {
+            throw new BusinessException(OAUTH_TOKEN_REQUEST_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/OauthUserResourceProvider.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/OauthUserResourceProvider.java
@@ -1,0 +1,39 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.farmsystem.homepage.domain.user.entity.SocialType;
+import org.farmsystem.homepage.global.error.exception.BusinessException;
+import org.springframework.stereotype.Component;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.OAUTH_USER_RESOURCE_FAILED;
+
+// OAuth 토큰으로 사용자 정보 요청 클래스
+@Service
+public class OauthUserResourceProvider {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public JsonNode getUserResource(String accessToken, SocialType socialType) throws JsonProcessingException {
+        String apiUrl = socialType.equals(SocialType.GOOGLE)
+                ? "https://www.googleapis.com/oauth2/v3/userinfo"
+                : "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(apiUrl, HttpMethod.GET, entity, String.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK || Objects.isNull(response.getBody())) {
+            throw new BusinessException(OAUTH_USER_RESOURCE_FAILED);
+        }
+        return new ObjectMapper().readTree(response.getBody());
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/TokenService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/TokenService.java
@@ -1,0 +1,74 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.user.dto.request.UserTokenRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
+import org.farmsystem.homepage.global.config.auth.jwt.JwtProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+    private final JwtProvider jwtProvider;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh-token-expire-time}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
+    public String issueNewAccessToken(Long userId) {
+        return jwtProvider.getIssueToken(userId, true);
+    }
+
+    public String issueNewRefreshToken(Long userId) {
+        return jwtProvider.getIssueToken(userId, false);
+    }
+
+    public UserTokenResponseDTO issueTempToken(Long userId) {
+        String accessToken = issueNewAccessToken(userId);
+        String refreshToken = issueNewRefreshToken(userId);
+        return UserTokenResponseDTO.of(accessToken, refreshToken);
+    }
+
+    public UserTokenResponseDTO issueToken(Long userId) {
+
+        String accessToken = issueNewAccessToken(userId);
+
+        String redisKey = "RT:" + userId;
+        String storedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+
+        if (storedRefreshToken == null) {
+            storedRefreshToken = issueNewRefreshToken(userId);
+            redisTemplate.opsForValue().set(redisKey, storedRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+        }
+
+        return UserTokenResponseDTO.of(accessToken, storedRefreshToken);
+    }
+
+    public UserTokenResponseDTO reissue(UserTokenRequestDTO uerTokenRequest) throws JsonProcessingException {
+        Long userId = Long.valueOf(jwtProvider.decodeJwtPayloadSubject(uerTokenRequest.accessToken()));
+
+        String refreshToken = uerTokenRequest.refreshToken();
+        String redisKey = "RT:" + userId;
+
+        jwtProvider.validateRefreshToken(refreshToken);
+
+        String newAccessToken = issueNewAccessToken(userId);
+        String newRefreshToken = issueNewRefreshToken(userId);
+        redisTemplate.opsForValue().set(redisKey, newRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
+
+        String storedRefreshToken = redisTemplate.opsForValue().get(redisKey);
+        jwtProvider.equalsRefreshToken(newRefreshToken, storedRefreshToken);
+
+        return UserTokenResponseDTO.of(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(Long userId) {
+        String redisKey = "RT:" + userId;
+        redisTemplate.delete(redisKey);
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -3,17 +3,22 @@ package org.farmsystem.homepage.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.apply.entity.PassedApply;
 import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
+import org.farmsystem.homepage.domain.user.dto.request.UserInfoUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserInfoUpdateResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.global.common.S3Service;
 import org.farmsystem.homepage.global.config.auth.jwt.JwtProvider;
 import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
 
 import static org.farmsystem.homepage.global.error.ErrorCode.AUTHENTICATION_FAILED;
 import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
@@ -23,6 +28,7 @@ import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
 @RequiredArgsConstructor
 public class UserService {
     private final JwtProvider jwtProvider;
+    private final S3Service s3Service;
     private final UserRepository userRepository;
     private final PassedApplyRepository passedApplyRepository;
 
@@ -49,6 +55,25 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
         return UserInfoResponseDTO.from(user);
+    }
+
+    // 사용자 정보 수정
+    @Transactional
+    public UserInfoUpdateResponseDTO updateUserInfo(Long userId, UserInfoUpdateRequestDTO userUpdateRequestDTO) throws IOException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        if (userUpdateRequestDTO.phoneNumber() != null) {
+            user.setPhoneNumber(userUpdateRequestDTO.phoneNumber());
+        }
+
+        if (userUpdateRequestDTO.profileImage() != null) {
+            String profileImageUrl = s3Service.uploadFile(userUpdateRequestDTO.profileImage(), "profile");
+            user.setProfileImageUrl(profileImageUrl);
+        }
+
+        userRepository.save(user);
+        return UserInfoUpdateResponseDTO.from(user);
     }
 
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -1,0 +1,28 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.farmsystem.homepage.domain.apply.entity.PassedApply;
+import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
+import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.AUTHENTICATION_FAILED;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final PassedApplyRepository passedApplyRepository;
+
+    public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
+        System.out.println("studentNumber = " + userVerifyRequest.studentNumber());
+        PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
+                .orElseThrow(() -> new UnauthorizedException(AUTHENTICATION_FAILED));
+        System.out.println("verifiedUser = " + verifiedUser.getName());
+        return new UserVerifyResponseDTO(true, verifiedUser.getName());
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -27,23 +27,9 @@ import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
-    private final JwtProvider jwtProvider;
     private final S3Service s3Service;
     private final UserRepository userRepository;
     private final PassedApplyRepository passedApplyRepository;
-
-    public String issueNewAccessToken(Long userId) {
-        return jwtProvider.getIssueToken(userId, true);
-    }
-    public String issueNewRefreshToken(Long userId) {
-        return jwtProvider.getIssueToken(userId, false);
-    }
-
-    public UserTokenResponseDTO issueTempToken(Long userId) {
-        String accessToken = issueNewAccessToken(userId);
-        String refreshToken = issueNewRefreshToken(userId);
-        return UserTokenResponseDTO.of(accessToken, refreshToken);
-    }
 
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
         PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
@@ -59,16 +45,16 @@ public class UserService {
 
     // 사용자 정보 수정
     @Transactional
-    public UserInfoUpdateResponseDTO updateUserInfo(Long userId, UserInfoUpdateRequestDTO userUpdateRequestDTO) throws IOException {
+    public UserInfoUpdateResponseDTO updateUserInfo(Long userId, UserInfoUpdateRequestDTO userUpdateRequest) throws IOException {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
 
-        if (userUpdateRequestDTO.phoneNumber() != null) {
-            user.setPhoneNumber(userUpdateRequestDTO.phoneNumber());
+        if (userUpdateRequest.phoneNumber() != null) {
+            user.setPhoneNumber(userUpdateRequest.phoneNumber());
         }
 
-        if (userUpdateRequestDTO.profileImage() != null) {
-            String profileImageUrl = s3Service.uploadFile(userUpdateRequestDTO.profileImage(), "profile");
+        if (userUpdateRequest.profileImage() != null) {
+            String profileImageUrl = s3Service.uploadFile(userUpdateRequest.profileImage(), "profile");
             user.setProfileImageUrl(profileImageUrl);
         }
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.apply.entity.PassedApply;
 import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.global.config.auth.jwt.JwtProvider;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,8 +17,21 @@ import static org.farmsystem.homepage.global.error.ErrorCode.AUTHENTICATION_FAIL
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
-
+    private final JwtProvider jwtProvider;
     private final PassedApplyRepository passedApplyRepository;
+
+    public String issueNewAccessToken(Long userId) {
+        return jwtProvider.getIssueToken(userId, true);
+    }
+    public String issueNewRefreshToken(Long userId) {
+        return jwtProvider.getIssueToken(userId, false);
+    }
+
+    public UserTokenResponseDTO issueTempToken(Long userId) {
+        String accessToken = issueNewAccessToken(userId);
+        String refreshToken = issueNewRefreshToken(userId);
+        return new UserTokenResponseDTO(accessToken, refreshToken);
+    }
 
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
         System.out.println("studentNumber = " + userVerifyRequest.studentNumber());

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -4,20 +4,26 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.apply.entity.PassedApply;
 import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserTokenResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.farmsystem.homepage.domain.user.repository.UserRepository;
 import org.farmsystem.homepage.global.config.auth.jwt.JwtProvider;
+import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.farmsystem.homepage.global.error.ErrorCode.AUTHENTICATION_FAILED;
+import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class UserService {
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
     private final PassedApplyRepository passedApplyRepository;
 
     public String issueNewAccessToken(Long userId) {
@@ -30,14 +36,19 @@ public class UserService {
     public UserTokenResponseDTO issueTempToken(Long userId) {
         String accessToken = issueNewAccessToken(userId);
         String refreshToken = issueNewRefreshToken(userId);
-        return new UserTokenResponseDTO(accessToken, refreshToken);
+        return UserTokenResponseDTO.of(accessToken, refreshToken);
     }
 
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
-        System.out.println("studentNumber = " + userVerifyRequest.studentNumber());
         PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
                 .orElseThrow(() -> new UnauthorizedException(AUTHENTICATION_FAILED));
-        System.out.println("verifiedUser = " + verifiedUser.getName());
-        return new UserVerifyResponseDTO(true, verifiedUser.getName());
+        return UserVerifyResponseDTO.from(true, verifiedUser.getName());
     }
+
+    public UserInfoResponseDTO getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        return UserInfoResponseDTO.from(user);
+    }
+
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
         PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
                 .orElseThrow(() -> new UnauthorizedException(AUTHENTICATION_FAILED));
-        return UserVerifyResponseDTO.from(true, verifiedUser.getName());
+        return UserVerifyResponseDTO.from(true, verifiedUser);
     }
 
     public UserInfoResponseDTO getUserInfo(Long userId) {

--- a/src/main/java/org/farmsystem/homepage/global/common/HealthCheckApi.java
+++ b/src/main/java/org/farmsystem/homepage/global/common/HealthCheckApi.java
@@ -21,24 +21,5 @@ public interface HealthCheckApi {
             @ApiResponse(responseCode = "404", description = "서버를 찾을 수 없음")
     })
     ResponseEntity<SuccessResponse<?>> FarmSysytemServer();
-
-    @Operation(
-            summary = "임시 토큰 발급 API",
-            description = "UserId로 임시 토큰을 발급받는 API입니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "201",
-                    description = "토큰 발급 성공",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = SuccessResponse.class)
-                    )
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
-    })
-    ResponseEntity<SuccessResponse<?>> getToken(
-            @Parameter(description = "userId, 임의 입력값", required = true, example = "1")
-            Long userId
-    );
+    
 }

--- a/src/main/java/org/farmsystem/homepage/global/common/HealthCheckController.java
+++ b/src/main/java/org/farmsystem/homepage/global/common/HealthCheckController.java
@@ -19,16 +19,4 @@ public class HealthCheckController implements HealthCheckApi {
         return SuccessResponse.ok("Hello! FarmSysytem Server!");
     }
 
-    // 임시 토큰 발급 API. 추후 로그인 기능이 완성되면 삭제할 예정
-    @PostMapping("/token/{userId}")
-    public ResponseEntity<SuccessResponse<?>> getToken(@PathVariable Long userId) {
-        String accessToken = jwtProvider.getIssueToken(userId, true);
-        String refreshToken = jwtProvider.getIssueToken(userId, false);
-
-        Map<String, String> tokens = new HashMap<>();
-        tokens.put("accessToken", accessToken);
-        tokens.put("refreshToken", refreshToken);
-
-        return SuccessResponse.created(tokens);
-    }
 }

--- a/src/main/java/org/farmsystem/homepage/global/common/S3Service.java
+++ b/src/main/java/org/farmsystem/homepage/global/common/S3Service.java
@@ -1,0 +1,49 @@
+package org.farmsystem.homepage.global.common;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file, String directory) throws IOException {
+        String uniqueFileName = UUID.randomUUID().toString() + getFileExtension(file.getOriginalFilename());
+        String filePath = uniqueFileName;
+
+        try (InputStream inputStream = file.getInputStream()) {
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(file.getContentType());
+            metadata.setContentLength(file.getSize());
+
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, filePath, inputStream, metadata);
+
+            amazonS3.putObject(putObjectRequest);
+        } catch (IOException e) {
+            throw new IOException("파일 업로드 중 오류 발생: " + e.getMessage(), e);
+        }
+
+        return amazonS3.getUrl(bucketName, filePath).toString();
+    }
+
+
+    private String getFileExtension(String fileName) {
+        int lastDotIndex = fileName.lastIndexOf(".");
+        return (lastDotIndex > 0) ? fileName.substring(lastDotIndex) : "";
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/global/config/RedisConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package org.farmsystem.homepage.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/global/config/S3Config.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/S3Config.java
@@ -1,0 +1,35 @@
+package org.farmsystem.homepage.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -31,9 +31,9 @@ public class SecurityConfig {
             "v3/api-docs/**",
 
             /* api */
-            "token/**",
-            "api/user/verify",
             "api/apply/**",
+            "api/user/token/**",
+            "api/user/verify/**",
             };
 
     @Bean

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
             "api/user/token/**",
             "api/user/verify/**",
             "api/user/login/**",
+            "api/user/reissue/**",
             };
 
     @Bean

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
 
             /* api */
             "token/**",
+            "api/user/verify",
             "api/apply/**",
             };
 

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
             "api/apply/**",
             "api/user/token/**",
             "api/user/verify/**",
+            "api/user/login/**",
             };
 
     @Bean

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -55,7 +55,13 @@ public enum ErrorCode {
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문을 찾을 수 없습니다."),
     CHOICE_NOT_FOUND(HttpStatus.NOT_FOUND, "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
-    APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원 내용입니다.");
+    APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원 내용입니다."),
+
+    /**
+     * User Error
+     */
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -60,8 +60,9 @@ public enum ErrorCode {
     /**
      * User Error
      */
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다.");
-
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -62,6 +62,12 @@ public enum ErrorCode {
      */
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "사용자 인증에 실패하였습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    /**
+     * Oauth Error
+     */
+    OAUTH_TOKEN_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 토큰 요청에 실패하였습니다."),
+    OAUTH_USER_RESOURCE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth 사용자 정보 조회에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #17  
## 🌱 작업 사항
- User 관련 기능 구현 (사용자 인증, 마이페이지 조회 및 수정 API)
- Oauth 관련 기능 구현 (카카오/구글 로그인, 리프레쉬토큰 재발급, 로그아웃)
- Redis, S3 관련 설정 및 연결

## 🌱 참고 사항
- 합격자 클래스 PassedApply , 트랙 기수 클래스 TrackHistory 새로 구현 (현재 기수는 User테이블에 한 번 더 저장하는 방식)
- 임시 토큰 -> 유저 엔티티로 이동

- 트랙 Enum 클래스 User랑 Apply에 둘 다 정의되어있는데 유틸 디렉토리에 옮기긴해야할 거 같음

- 회원 정보 관련 기능에 이메일 핸드폰 번호가 기능 명세 노션에 있어서 유저 엔티티에 추가 (회원정보 수정 가능불가능 정보 재확인 필요) 
- 로그인 트랙, 전화번호, 이메일 정보 어디서 가지고 오는지..? 합격자 테이블에는 해당 컬럼 없어서 지원서 테이블에서 가져와야할 거 같기도
- 합격자조회 API 아직 없는듯
- Oauth 쪽 지금 User, Token 등등 클래스 어떻게 분리할 지 매우 고민중 (코드 정리도 좀 필요할 듯)

<이후 작업>
- DTO validation 추가
- 스웨거 명세 추가
- Redis 배포 설정
- Oauth 리다이렉트 URL 배포 주소 설정 & YML분리 작업
