### PR TITLE
[feat] #26 관리자 권한 

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/Role.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/Role.java
@@ -1,0 +1,19 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role implements GrantedAuthority {
+    USER("팜 회원"),
+    ADMIN("관리자");
+
+    private final String title;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/TrackHistory.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/TrackHistory.java
@@ -19,8 +19,8 @@ public class TrackHistory {
     @Column(nullable = false)
     private Track track;
 
-    @Column(nullable = false)
-    private int generation;
+    @Column
+    private Integer generation;
 
 
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -20,6 +20,10 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
     @Column(nullable = false, length = 10)
     private String name;
 
@@ -43,8 +47,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Track track;
 
-    @Column(nullable = true)
-    private int generation;
+    @Column
+    private Integer generation;
 
     @ColumnDefault("false")
     private boolean isDeleted;
@@ -59,10 +63,15 @@ public class User extends BaseTimeEntity {
     private List<TrackHistory> trackHistories;
 
     @Builder
-    public User(String profileImageUrl,String name, String studentNumber, SocialType socialType) {
+    public User(String profileImageUrl,String name, String studentNumber, SocialType socialType, Role role) {
         this.profileImageUrl = profileImageUrl;
         this.name = name;
         this.studentNumber = studentNumber;
         this.socialType = socialType;
+        this.role = role;
+    }
+
+    public void updateRole(Role role) {
+        this.role = role;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package org.farmsystem.homepage.domain.user.repository;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User,Long>{
-    User findByStudentNumber(String studentNumber);
+    Optional<User> findByStudentNumber(String studentNumber);
 }

--- a/src/main/java/org/farmsystem/homepage/global/config/RedisConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/RedisConfig.java
@@ -3,6 +3,7 @@ package org.farmsystem.homepage.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -10,6 +11,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
     @Bean
+    @Primary
     public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(connectionFactory);

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -54,7 +54,11 @@ public class SecurityConfig {
                 .exceptionHandling(exceptionHandlingConfigurer ->
                         exceptionHandlingConfigurer.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
-                        authorizationManagerRequestMatcherRegistry.anyRequest().authenticated())
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
+                                .requestMatchers(whiteList).permitAll()
+                                .anyRequest().authenticated()
+                )
                 .addFilter(corsConfig.corsFilter())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package org.farmsystem.homepage.global.config.auth.jwt;
 
+import org.farmsystem.homepage.domain.user.entity.Role;
 import org.farmsystem.homepage.global.config.auth.UserAuthentication;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
@@ -14,6 +15,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -26,7 +28,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         final String accessToken = getAccessTokenFromHttpServletRequest(request);
         jwtProvider.validateAccessToken(accessToken);
         final Long userId = jwtProvider.getSubject(accessToken);
-        setAuthentication(request, userId);
+        final Role role = jwtProvider.getRole(accessToken);
+        setAuthentication(request, userId, role);
         filterChain.doFilter(request, response);
     }
 
@@ -38,8 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         throw new UnauthorizedException(ErrorCode.INVALID_ACCESS_TOKEN);
     }
 
-    private void setAuthentication(HttpServletRequest request, Long userId) {
-        UserAuthentication authentication = new UserAuthentication(userId, null, null);
+    private void setAuthentication(HttpServletRequest request, Long userId, Role role) {
+        UserAuthentication authentication = new UserAuthentication(userId, null, List.of(role));
         authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/jwt/JwtProvider.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package org.farmsystem.homepage.global.config.auth.jwt;
 
+import org.farmsystem.homepage.domain.user.entity.Role;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,9 +29,9 @@ public class JwtProvider {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public String getIssueToken(Long userId, boolean isAccessToken) {
-        if (isAccessToken) return generateToken(userId, ACCESS_TOKEN_EXPIRE_TIME);
-        else return generateToken(userId, REFRESH_TOKEN_EXPIRE_TIME);
+    public String getIssueToken(Long userId, Role role, boolean isAccessToken) {
+        if (isAccessToken) return generateToken(userId, role, ACCESS_TOKEN_EXPIRE_TIME);
+        else return generateToken(userId, role, REFRESH_TOKEN_EXPIRE_TIME);
     }
 
     public void validateAccessToken(String accessToken) {
@@ -65,12 +66,13 @@ public class JwtProvider {
                 .getSubject());
     }
 
-    private String generateToken(Long userId, long tokenTime) {
+    private String generateToken(Long userId, Role role, long tokenTime) {
         final Date now = new Date();
         final Date expiration = new Date(now.getTime() + tokenTime);
         return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setSubject(String.valueOf(userId))
+                .claim("role", role.name())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -94,6 +96,11 @@ public class JwtProvider {
                 new String(Base64.getDecoder().decode(oldAccessToken.split("\\.")[1]), StandardCharsets.UTF_8),
                 Map.class
         ).get("sub").toString();
+    }
+
+    public Role getRole(String token) {
+        String role = getJwtParser().parseClaimsJws(token).getBody().get("role", String.class);
+        return Role.valueOf(role);
     }
 
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #26 #25
 
## 🌱 작업 사항
### [주요 작업] 관리자 권한 제어
1. `Role` 엔티티 추가 후, `Spring Security`에 리소스 제어
2. jwt 관련 코드에 `Role` 정보 함께 담도록 수정

### [기타 작업] - 개발하며 발생한 오류 수정
1. `Optional`
`UserRepository.findByStudentNumber()`가 `Optional<User>`을 반환하도록 수정


2. `redisTemplate` 관련 이슈
- `TokenService`가 어떤 빈을 사용해야 할 지 몰라서 에러 발생함.
- Spring Boot가 제공하는 `StringRedisTemplate`이 자동으로 빈으로 등록되어있었음
- 우리가 만든 `redisTemplate`도 동시에 존재해서 에러 발생함
- `redisTemplate`에 `@Primary` 추가하여 이 템플릿을 기본 빈으로 설정함


3. `generation `타입 수정
- 각 클래스에서 `generation`을 보면
- `User`에는 `nullable=true`, `int`로 되어있는데,
- `TrackHistory`에는 `nullable=false`, `int`로 되어있었음.
- 위 사항이 자꾸문제를 발생시켜서 `Integer`로 통일함.

## 🌱 참고 사항
### [📌필독: 관리자 권한 리소스 권한 제어 방법] 
@floreo1242 
@hysong4u 

![image](https://github.com/user-attachments/assets/d36a8417-06b7-4e6a-badf-8356906c560f)
`SecurityConfig` 확인 ->  `/api/admin`하위 경로만 관리자 페이지로 인식함.

✅ To-Do
1. 본인이 맡은 API 개발하되, 관리자 API는 앞에 '`Admin`'을 붙인다. 
e.g. `NewsApi `-> `AdminNewsApi`
2. 경로를 `/api/admin`으로 설정한다.

<img width="483" alt="스크린샷 2025-02-23 오후 10 56 43" src="https://github.com/user-attachments/assets/0c174417-8c15-4f80-8326-662495cb2a3f" />

3. Test
관리자 권한을 가진 유저와 일반 유저를 생성해서 테스트

![image](https://github.com/user-attachments/assets/c37f0ac7-5131-44bb-ba47-5cec699b761f)

-> 잘 되었다면 이렇게 뜸


