### PR TITLE
[fix] release/v0.0.2 수정 후 병합

### DIFF
--- a/.github/workflows/prod-cicd.yml
+++ b/.github/workflows/prod-cicd.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up JDK 17
       uses: actions/setup-java@v4
@@ -45,12 +47,11 @@ jobs:
         echo "SOURCE_BRANCH=${{ github.head_ref }}"
         echo "::set-output name=branch::${{ github.head_ref }}"
         
-    - name: Extract version info
+    - name: Extract version info from Git tag
       id: vars
       run: |
-        VERSION_NUMBER=${{ steps.pr_info.outputs.branch }}
-        # 접두사 "release/v"를 제거하여 버전 번호만 추출
-        VERSION_NUMBER=${VERSION_NUMBER#"release/v"}
+        VERSION_TAG=$(git describe --tags --abbrev=0)
+        VERSION_NUMBER=${VERSION_NUMBER#v}
         echo "VERSION_NUMBER=${VERSION_NUMBER}"
         echo "::set-output name=version::${VERSION_NUMBER}"
 


### PR DESCRIPTION
## 🌱 작업 사항
release/v0.0.2 브랜치에서 직접 수정 후 머지

## 🌱 참고 사항
release 브랜치에서 main에 반영할 준비가 되면 tag 생성 (v0.0.2 형식으로)
그러면 최근 태그를 기준으로 버전 정보 추출 후 반영됨

기존에는 release 브랜치 명에서 가져오려고 했으나 main으로 병합되는 순간 pr 정보가 사라져 버전 정보를 잃어버렸었음