### PR TITLE
[fix] Swagger에서 토큰을 헤더에 포함하도록 수정 

### DIFF
--- a/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package org.farmsystem.homepage.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
@@ -29,8 +30,11 @@ public class SwaggerConfig {
 
         Components components = new Components().addSecuritySchemes("token", securityScheme);
 
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("token");
+
         return new OpenAPI()
                 .info(info)
-                .components(components);
+                .components(components)
+                .addSecurityItem(securityRequirement);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #39 
 
## 🌱 작업 사항
- 각 API 호출 시 토큰을 헤더에 포함시키기 위해 SecurityRequirement 추가하여
- 모든 API 요청에 대해 'token' SecurityScheme 적용
- 미사용 import 제거

## 🌱 참고 사항
- 예전에 했던 프로젝트 코드 참고해서 수정한거라 정확히 이게 맞는지는 확실치 않은데 일단 로컬에서는 잘 돼

### 기존 (상단 Authorize, Curl 참고)
![image](https://github.com/user-attachments/assets/3354af94-1347-427e-b455-98139f1dc195)
### 변경
![image](https://github.com/user-attachments/assets/f48baf08-fbc4-49d0-bd7c-34cd93b24e46)
