### PR TITLE
[feat] 지원 추가 구현

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
@@ -40,6 +40,7 @@ public class ApplyController {
         return SuccessResponse.ok(applyService.saveApply(request, true));
     }
 
+    // 지원서 불러오기
     @PostMapping("/load")
     public ResponseEntity<SuccessResponse<?>> loadApply(@RequestBody @Valid LoadApplyRequestDTO request) {
         return SuccessResponse.ok(applyService.loadApply(request));

--- a/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
@@ -22,7 +22,8 @@ public class ApplyController {
         return SuccessResponse.ok(applyService.getQuestions());
     }
 
-    @PostMapping("/info")
+    // 지원서 생성
+    @PostMapping
     public ResponseEntity<SuccessResponse<?>> createApply(@RequestBody @Valid CreateApplyRequestDTO request) {
         return SuccessResponse.created(applyService.createApply(request));
     }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/controller/ApplyController.java
@@ -28,11 +28,13 @@ public class ApplyController {
         return SuccessResponse.created(applyService.createApply(request));
     }
 
+    // 지원서 임시저장
     @PostMapping("/save")
     public ResponseEntity<SuccessResponse<?>> saveApply(@RequestBody @Valid ApplyRequestDTO request) {
         return SuccessResponse.ok(applyService.saveApply(request, false));
     }
 
+    // 지원서 제출
     @PostMapping("/submit")
     public ResponseEntity<SuccessResponse<?>> submitApply(@RequestBody @Valid ApplyRequestDTO request) {
         return SuccessResponse.ok(applyService.saveApply(request, true));

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/AnswerDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/AnswerDTO.java
@@ -1,10 +1,15 @@
 package org.farmsystem.homepage.domain.apply.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
-public record AnswerDTO(Long questionId, String content, List<Long> choiceId) {
-    // TODO: Validation 추가
+public record AnswerDTO(
+        @NotNull
+        Long questionId,
+        String content,
+        List<Long> choiceId
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/ApplyRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/ApplyRequestDTO.java
@@ -1,9 +1,19 @@
 package org.farmsystem.homepage.domain.apply.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import org.farmsystem.homepage.domain.apply.dto.AnswerDTO;
+import org.farmsystem.homepage.domain.common.entity.Track;
 
 import java.util.List;
 
-public record ApplyRequestDTO(Long applyId, List<AnswerDTO> answers) {
-    // TODO: Validation 추가
+public record ApplyRequestDTO(
+        @NotNull
+        Long applyId,
+        String name,
+        String major,
+        String phoneNumber,
+        String email,
+        Track track,
+        List<AnswerDTO> answers
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/CreateApplyRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/CreateApplyRequestDTO.java
@@ -1,5 +1,15 @@
 package org.farmsystem.homepage.domain.apply.dto.request;
 
-public record CreateApplyRequestDTO(String password, String name, String major, String studentNumber, String phoneNumber, String email) {
-    // TODO: Validation 추가
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateApplyRequestDTO(
+        @NotBlank
+        @Size(min = 10, max = 10)
+        String studentNumber,
+
+        @NotBlank
+        @Size(min = 6, max = 6)
+        String password
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/LoadApplyRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/request/LoadApplyRequestDTO.java
@@ -1,5 +1,15 @@
 package org.farmsystem.homepage.domain.apply.dto.request;
 
-public record LoadApplyRequestDTO(String studentNumber, String password) {
-    // TODO: Validation 추가
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record LoadApplyRequestDTO(
+        @NotBlank
+        @Size(min = 10, max = 10)
+        String studentNumber,
+
+        @NotBlank
+        @Size(min = 6, max = 6)
+        String password
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/CreateApplyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/CreateApplyResponseDTO.java
@@ -3,5 +3,7 @@ package org.farmsystem.homepage.domain.apply.dto.response;
 import lombok.Builder;
 
 @Builder
-public record CreateApplyResponseDTO(Long applyId) {
+public record CreateApplyResponseDTO(
+        Long applyId
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/LoadApplyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/LoadApplyResponseDTO.java
@@ -2,11 +2,11 @@ package org.farmsystem.homepage.domain.apply.dto.response;
 
 import lombok.Builder;
 import org.farmsystem.homepage.domain.apply.dto.AnswerDTO;
-import org.farmsystem.homepage.domain.apply.entity.ApplyStatus;
+import org.farmsystem.homepage.domain.apply.entity.ApplyStatusEnum;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record LoadApplyResponseDTO(Long applyId, ApplyStatus status, LocalDateTime updatedAt, List<AnswerDTO> answers) {
+public record LoadApplyResponseDTO(Long applyId, ApplyStatusEnum status, LocalDateTime updatedAt, List<AnswerDTO> answers) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/LoadApplyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/LoadApplyResponseDTO.java
@@ -3,10 +3,21 @@ package org.farmsystem.homepage.domain.apply.dto.response;
 import lombok.Builder;
 import org.farmsystem.homepage.domain.apply.dto.AnswerDTO;
 import org.farmsystem.homepage.domain.apply.entity.ApplyStatusEnum;
+import org.farmsystem.homepage.domain.common.entity.Track;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
-public record LoadApplyResponseDTO(Long applyId, ApplyStatusEnum status, LocalDateTime updatedAt, List<AnswerDTO> answers) {
+public record LoadApplyResponseDTO(
+        Long applyId,
+        ApplyStatusEnum status,
+        LocalDateTime updatedAt,
+        String name,
+        String major,
+        String phoneNumber,
+        String email,
+        Track track,
+        List<AnswerDTO> answers
+) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
@@ -13,7 +13,10 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "apply")
+@Table(
+        name = "apply",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"student_number", "password"})
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Apply extends BaseTimeEntity {
 

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
@@ -45,7 +45,7 @@ public class Apply extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private ApplyStatus status;
+    private ApplyStatusEnum status;
 
     @Builder
     public Apply(String password, String name, String major, String studentNumber, String phoneNumber, String email) {
@@ -55,13 +55,13 @@ public class Apply extends BaseTimeEntity {
         this.studentNumber = studentNumber;
         this.phoneNumber = phoneNumber;
         this.email = email;
-        this.status = ApplyStatus.DRAFT;
+        this.status = ApplyStatusEnum.DRAFT;
     }
 
     @OneToMany(mappedBy = "apply")
     private List<Answer> answers = new ArrayList<>();
 
-    public void updateStatus(ApplyStatus status) {
+    public void updateStatus(ApplyStatusEnum status) {
         this.status = status;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
@@ -64,4 +64,24 @@ public class Apply extends BaseTimeEntity {
     public void updateStatus(ApplyStatusEnum status) {
         this.status = status;
     }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateMajor(String major) {
+        this.major = major;
+    }
+
+    public void updatePhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updateTrack(Track track) {
+        this.track = track;
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
@@ -2,6 +2,7 @@ package org.farmsystem.homepage.domain.apply.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,12 +13,11 @@ import lombok.NoArgsConstructor;
 public class ApplyStatus {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long statusId;
-
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
-    @Column(nullable = false)
-    private ApplyStatusEnum status;
+    @Builder
+    public ApplyStatus(String studentNumber) {
+        this.studentNumber = studentNumber;
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
@@ -1,5 +1,23 @@
 package org.farmsystem.homepage.domain.apply.entity;
 
-public enum ApplyStatus {
-    DRAFT, SAVED, SUBMITTED
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "apply_status")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplyStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long statusId;
+
+    @Column(nullable = false, length = 20)
+    private String studentNumber;
+
+    @Column(nullable = false)
+    private ApplyStatusEnum status;
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatusEnum.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatusEnum.java
@@ -1,0 +1,5 @@
+package org.farmsystem.homepage.domain.apply.entity;
+
+public enum ApplyStatusEnum {
+    DRAFT, SAVED, SUBMITTED
+}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/exception/AnswerNotFoundException.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/exception/AnswerNotFoundException.java
@@ -1,9 +1,0 @@
-package org.farmsystem.homepage.domain.apply.exception;
-
-import org.farmsystem.homepage.global.error.ErrorCode;
-import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
-
-public class AnswerNotFoundException extends EntityNotFoundException {
-
-    public AnswerNotFoundException() {super(ErrorCode.ANSWER_NOT_FOUND);}
-}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/exception/ApplyAlreadySubmittedException.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/exception/ApplyAlreadySubmittedException.java
@@ -1,9 +1,0 @@
-package org.farmsystem.homepage.domain.apply.exception;
-
-import org.farmsystem.homepage.global.error.ErrorCode;
-import org.farmsystem.homepage.global.error.exception.BusinessException;
-
-public class ApplyAlreadySubmittedException extends BusinessException {
-
-    public ApplyAlreadySubmittedException() {super(ErrorCode.APPLY_ALREADY_SUBMITTED);}
-}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/exception/ApplyNotFoundException.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/exception/ApplyNotFoundException.java
@@ -1,9 +1,0 @@
-package org.farmsystem.homepage.domain.apply.exception;
-
-import org.farmsystem.homepage.global.error.ErrorCode;
-import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
-
-public class ApplyNotFoundException extends EntityNotFoundException {
-
-    public ApplyNotFoundException() {super(ErrorCode.APPLY_NOT_FOUND);}
-}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/exception/ChoiceNotFoundException.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/exception/ChoiceNotFoundException.java
@@ -1,9 +1,0 @@
-package org.farmsystem.homepage.domain.apply.exception;
-
-import org.farmsystem.homepage.global.error.ErrorCode;
-import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
-
-public class ChoiceNotFoundException extends EntityNotFoundException {
-
-    public ChoiceNotFoundException() {super(ErrorCode.CHOICE_NOT_FOUND);}
-}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/exception/QuestionNotFoundException.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/exception/QuestionNotFoundException.java
@@ -1,9 +1,0 @@
-package org.farmsystem.homepage.domain.apply.exception;
-
-import org.farmsystem.homepage.global.error.ErrorCode;
-import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
-
-public class QuestionNotFoundException extends EntityNotFoundException {
-
-    public QuestionNotFoundException() {super(ErrorCode.QUESTION_NOT_FOUND);}
-}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
-    Optional<Apply> findByStudentNumberAndPassword(String studentNumber, String password);
+    Optional<Apply> findByStudentNumber(String studentNumber);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyStatusRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyStatusRepository.java
@@ -1,0 +1,11 @@
+package org.farmsystem.homepage.domain.apply.repository;
+
+import org.farmsystem.homepage.domain.apply.entity.ApplyStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApplyStatusRepository extends JpaRepository<ApplyStatus, Long> {
+
+    boolean existsByStudentNumber(String studentNumber);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -58,12 +58,8 @@ public class ApplyService {
     @Transactional
     public CreateApplyResponseDTO createApply(CreateApplyRequestDTO request) {
         Apply apply = Apply.builder()
-                .password(passwordEncoder.encode(request.password()))
-                .name(request.name())
-                .major(request.major())
                 .studentNumber(request.studentNumber())
-                .phoneNumber(request.phoneNumber())
-                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
                 .build();
         Apply savedApply = applyRepository.save(apply);
         return CreateApplyResponseDTO.builder()

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -73,7 +73,7 @@ public class ApplyService {
     public ApplyResponseDTO saveApply(ApplyRequestDTO request, boolean submitFlag) {
         Apply apply = applyRepository.findById(request.applyId())
                 .orElseThrow(ApplyNotFoundException::new);
-        if (apply.getStatus() == ApplyStatus.SUBMITTED) {
+        if (apply.getStatus() == ApplyStatusEnum.SUBMITTED) {
             throw new ApplyAlreadySubmittedException();
         }
         handleApplyStatus(apply, submitFlag);
@@ -109,10 +109,10 @@ public class ApplyService {
 
     private void handleApplyStatus(Apply apply, boolean isSubmit) {
         if (isSubmit) {
-            apply.updateStatus(ApplyStatus.SUBMITTED);
+            apply.updateStatus(ApplyStatusEnum.SUBMITTED);
         } else {
-            if (apply.getStatus() == ApplyStatus.DRAFT) {
-                apply.updateStatus(ApplyStatus.SAVED);
+            if (apply.getStatus() == ApplyStatusEnum.DRAFT) {
+                apply.updateStatus(ApplyStatusEnum.SAVED);
             }
         }
     }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -90,7 +90,7 @@ public class ApplyService {
         Apply apply = applyRepository.findByStudentNumber(request.studentNumber())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLY_NOT_FOUND));
         if (!passwordEncoder.matches(request.password(), apply.getPassword())) {
-            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+            throw new BusinessException(ErrorCode.APPLY_INVALID_PASSWORD);
         }
         return LoadApplyResponseDTO.builder()
                 .applyId(apply.getApplyId())
@@ -118,6 +118,7 @@ public class ApplyService {
     private void handleApplyStatus(Apply apply, boolean isSubmit) {
         if (isSubmit) {
             applyStatusRepository.save(ApplyStatus.builder().studentNumber(apply.getStudentNumber()).build());
+            apply.updateStatus(ApplyStatusEnum.SUBMITTED);
         } else {
             if (apply.getStatus() == ApplyStatusEnum.DRAFT) {
                 apply.updateStatus(ApplyStatusEnum.SAVED);

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -87,12 +87,20 @@ public class ApplyService {
     }
 
     public LoadApplyResponseDTO loadApply(LoadApplyRequestDTO request) {
-        Apply apply = applyRepository.findByStudentNumberAndPassword(request.studentNumber(), passwordEncoder.encode(request.password()))
+        Apply apply = applyRepository.findByStudentNumber(request.studentNumber())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLY_NOT_FOUND));
+        if (!passwordEncoder.matches(request.password(), apply.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
         return LoadApplyResponseDTO.builder()
                 .applyId(apply.getApplyId())
                 .status(apply.getStatus())
                 .updatedAt(apply.getUpdatedAt())
+                .name(apply.getName())
+                .major(apply.getMajor())
+                .phoneNumber(apply.getPhoneNumber())
+                .email(apply.getEmail())
+                .track(apply.getTrack())
                 .answers(apply.getAnswers().stream()
                         .map(answer -> AnswerDTO.builder()
                                 .questionId(answer.getQuestion().getQuestionId())

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -11,6 +11,7 @@ import org.farmsystem.homepage.domain.apply.dto.response.LoadApplyResponseDTO;
 import org.farmsystem.homepage.domain.apply.entity.*;
 import org.farmsystem.homepage.domain.apply.exception.*;
 import org.farmsystem.homepage.domain.apply.repository.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +28,7 @@ public class ApplyService {
     private final AnswerRepository answerRepository;
     private final ChoiceRepository choiceRepository;
     private final AnswerChoiceRepository answerChoiceRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public List<QuestionDTO> getQuestions() {
         List<Question> questions = questionRepository.findAll();
@@ -54,8 +56,7 @@ public class ApplyService {
     @Transactional
     public CreateApplyResponseDTO createApply(CreateApplyRequestDTO request) {
         Apply apply = Apply.builder()
-                .password(request.password())
-                // TODO: password 암호화
+                .password(passwordEncoder.encode(request.password()))
                 .name(request.name())
                 .major(request.major())
                 .studentNumber(request.studentNumber())
@@ -86,8 +87,7 @@ public class ApplyService {
     }
 
     public LoadApplyResponseDTO loadApply(LoadApplyRequestDTO request) {
-        // TODO: password 암호화
-        Apply apply = applyRepository.findByStudentNumberAndPassword(request.studentNumber(), request.password())
+        Apply apply = applyRepository.findByStudentNumberAndPassword(request.studentNumber(), passwordEncoder.encode(request.password()))
                 .orElseThrow(ApplyNotFoundException::new);
         return LoadApplyResponseDTO.builder()
                 .applyId(apply.getApplyId())

--- a/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/auth/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -63,5 +65,10 @@ public class SecurityConfig {
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new ExceptionHandlerFilter(), JwtAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
     CHOICE_NOT_FOUND(HttpStatus.NOT_FOUND, "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
     APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원서입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     /**
      * User Error

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -56,11 +56,11 @@ public enum ErrorCode {
     /**
      * Apply Error
      */
-    APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "지원 내용을 찾을 수 없습니다."),
+    APPLY_NOT_FOUND(HttpStatus.NOT_FOUND, "지원서를 찾을 수 없습니다."),
     QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "질문을 찾을 수 없습니다."),
     CHOICE_NOT_FOUND(HttpStatus.NOT_FOUND, "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
-    APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원 내용입니다."),
+    APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원서입니다."),
 
     /**
      * User Error

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -61,7 +61,7 @@ public enum ErrorCode {
     CHOICE_NOT_FOUND(HttpStatus.NOT_FOUND, "선택지를 찾을 수 없습니다."),
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
     APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원서입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    APPLY_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 
     /**
      * User Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #20 
 
## 🌱 작업 사항
- 개별 Exception 클래스 삭제
- 에러코드 메시지 수정
- 임시저장 비밀번호 암호화
- DTO Validation 추가
- 중복 제출 방지를 위한 ApplyStatus 엔티티 추가
  - 이에 따라 기존 ApplyStatus 열거형은 ApplyStatusEnum으로 변경
- 요구사항에 맞게 세부 로직 수정
  - 기존 개인정보 생성 API은 지원서 생성 API로 변경
  - 임시저장, 제출 API에서 지원서 내용과 함께 개인정보도 추가로 저장
  - `아직 작성하지 않은 질문은 빈 텍스트로 요청`에서 `작성하지 않은 질문은 요청하지 않음` 으로 바뀜에 따라 임시저장 시 기존 답변이 없다면 생성 후 수정하도록 로직 추가
- apply 테이블에 학번, 비밀번호로 UNIQUE 제약조건 설정

## 🌱 참고 사항
- 제출 시 Apply의 status가 `SUBMITTED`가 되는건 단순 명시용으로, 중복 제출 여부는 ApplyStatus에 해당 학번이 존재하는지로 확인합니다.
