### PR TITLE
[feat] 지원 priority 구현 및 버그 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
@@ -27,19 +27,19 @@ public class Apply extends BaseTimeEntity {
     @Column(nullable = false, length = 100)
     private String password;
 
-    @Column(nullable = false, length = 10)
+    @Column(length = 10)
     private String name;
 
-    @Column(nullable = false, length = 50)
+    @Column(length = 50)
     private String major;
 
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
-    @Column(nullable = false, length = 20)
+    @Column(length = 20)
     private String phoneNumber;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String email;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Apply.java
@@ -13,10 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(
-        name = "apply",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"student_number", "password"})
-)
+@Table(name = "apply")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Apply extends BaseTimeEntity {
 

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/ApplyStatus.java
@@ -2,7 +2,6 @@ package org.farmsystem.homepage.domain.apply.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -16,7 +15,6 @@ public class ApplyStatus {
     @Column(nullable = false, length = 20)
     private String studentNumber;
 
-    @Builder
     public ApplyStatus(String studentNumber) {
         this.studentNumber = studentNumber;
     }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
@@ -25,6 +25,8 @@ public class Choice {
     @Column(nullable = false, length = 50)
     private String content;
 
+    private Integer priority;
+
     @OneToMany(mappedBy = "choice")
     private List<AnswerChoice> answerChoices = new ArrayList<>();
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
@@ -43,5 +43,6 @@ public class Question {
     private List<Answer> answers = new ArrayList<>();
 
     @OneToMany(mappedBy = "question")
+    @OrderBy("priority ASC")
     private List<Choice> choices =  new ArrayList<>();
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
@@ -3,9 +3,12 @@ package org.farmsystem.homepage.domain.apply.repository;
 import org.farmsystem.homepage.domain.apply.entity.Apply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
+
+    List<Apply> findAllByStudentNumber(String studentNumber);
 
     Optional<Apply> findByStudentNumber(String studentNumber);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/QuestionRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/QuestionRepository.java
@@ -3,5 +3,9 @@ package org.farmsystem.homepage.domain.apply.repository;
 import org.farmsystem.homepage.domain.apply.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    List<Question> findAllByOrderByTrackAscPriorityAsc();
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -117,12 +117,10 @@ public class ApplyService {
 
     private void handleApplyStatus(Apply apply, boolean isSubmit) {
         if (isSubmit) {
-            applyStatusRepository.save(ApplyStatus.builder().studentNumber(apply.getStudentNumber()).build());
+            applyStatusRepository.save(new ApplyStatus(apply.getStudentNumber()));
             apply.updateStatus(ApplyStatusEnum.SUBMITTED);
-        } else {
-            if (apply.getStatus() == ApplyStatusEnum.DRAFT) {
-                apply.updateStatus(ApplyStatusEnum.SAVED);
-            }
+        } else if (apply.getStatus() == ApplyStatusEnum.DRAFT) {
+            apply.updateStatus(ApplyStatusEnum.SAVED);
         }
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -58,6 +58,10 @@ public class ApplyService {
 
     @Transactional
     public CreateApplyResponseDTO createApply(CreateApplyRequestDTO request) {
+        List<Apply> applies = applyRepository.findAllByStudentNumber(request.studentNumber());
+        if (applies.stream().anyMatch(apply -> passwordEncoder.matches(request.password(), apply.getPassword()))) {
+            throw new BusinessException(ErrorCode.APPLY_ALREADY_EXIST);
+        }
         Apply apply = Apply.builder()
                 .studentNumber(request.studentNumber())
                 .password(passwordEncoder.encode(request.password()))

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -34,7 +34,7 @@ public class ApplyService {
     private final ApplyStatusRepository applyStatusRepository;
 
     public List<QuestionDTO> getQuestions() {
-        List<Question> questions = questionRepository.findAll();
+        List<Question> questions = questionRepository.findAllByOrderByTrackAscPriorityAsc();
         return questions.stream()
                 .map(question -> QuestionDTO.builder()
                         .questionId(question.getQuestionId())

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "답변을 찾을 수 없습니다."),
     APPLY_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "이미 제출한 지원서입니다."),
     APPLY_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    APPLY_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 존재하는 지원서입니다."),
 
     /**
      * User Error


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #43 
 
## 🌱 작업 사항
### 지원 priority 구현
1. 트랙으로 정렬 후 priority 정렬
2. Choice 엔티티에 priority 추가
3. Question의 선택지 조회 시 항상 priority 오름차순으로 조회 하도록 설정

### 버그 수정
1. Apply 엔티티의 NOT NULL이 아니어야 하는 column에 @Column nullable=false 옵션 삭제
2. Salt로 인해 UNIQUE 제약조건이 작동하지 않음 -> 지원서 생성 시 비밀번호 대조 후 에러 발생