### PR TITLE
[ refactor ] 지원 N+1 문제 관련 코드 개선

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Answer.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Answer.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,7 @@ public class Answer {
     }
 
     @OneToMany(mappedBy = "answer")
+    @BatchSize(size = 5)
     private List<AnswerChoice> answerChoices = new ArrayList<>();
 
     public void updateContent(String content) {

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
@@ -25,6 +25,7 @@ public class Choice {
     @Column(nullable = false, length = 50)
     private String content;
 
+    @Column(nullable = false)
     private int priority;
 
     @OneToMany(mappedBy = "choice")

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Choice.java
@@ -25,7 +25,7 @@ public class Choice {
     @Column(nullable = false, length = 50)
     private String content;
 
-    private Integer priority;
+    private int priority;
 
     @OneToMany(mappedBy = "choice")
     private List<AnswerChoice> answerChoices = new ArrayList<>();

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
@@ -37,6 +37,7 @@ public class Question {
 
     private Boolean isDuplicated;
 
+    @Column(nullable = false)
     private int priority;
 
     @OneToMany(mappedBy = "question")

--- a/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/entity/Question.java
@@ -37,7 +37,7 @@ public class Question {
 
     private Boolean isDuplicated;
 
-    private Integer priority;
+    private int priority;
 
     @OneToMany(mappedBy = "question")
     private List<Answer> answers = new ArrayList<>();

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
@@ -4,11 +4,8 @@ import org.farmsystem.homepage.domain.apply.entity.Apply;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
     List<Apply> findAllByStudentNumber(String studentNumber);
-
-    Optional<Apply> findByStudentNumber(String studentNumber);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/ApplyRepository.java
@@ -1,11 +1,13 @@
 package org.farmsystem.homepage.domain.apply.repository;
 
 import org.farmsystem.homepage.domain.apply.entity.Apply;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ApplyRepository extends JpaRepository<Apply, Long> {
 
+    @EntityGraph(attributePaths = {"answers"})
     List<Apply> findAllByStudentNumber(String studentNumber);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/repository/QuestionRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/repository/QuestionRepository.java
@@ -1,11 +1,13 @@
 package org.farmsystem.homepage.domain.apply.repository;
 
 import org.farmsystem.homepage.domain.apply.entity.Question;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
+    @EntityGraph(attributePaths = {"choices"})
     List<Question> findAllByOrderByTrackAscPriorityAsc();
 }

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -33,6 +33,7 @@ public class ApplyService {
     private final PasswordEncoder passwordEncoder;
     private final ApplyStatusRepository applyStatusRepository;
 
+    // 전체 질문 조회
     public List<QuestionDTO> getQuestions() {
         List<Question> questions = questionRepository.findAllByOrderByTrackAscPriorityAsc();
         return questions.stream()
@@ -56,6 +57,7 @@ public class ApplyService {
                 .collect(Collectors.toList());
     }
 
+    // 지원서 생성
     @Transactional
     public CreateApplyResponseDTO createApply(CreateApplyRequestDTO request) {
         List<Apply> applies = applyRepository.findAllByStudentNumber(request.studentNumber());
@@ -72,6 +74,7 @@ public class ApplyService {
                 .build();
     }
 
+    // 지원서 임시저장/제출
     @Transactional
     public ApplyResponseDTO saveApply(ApplyRequestDTO request, boolean submitFlag) {
         Apply apply = applyRepository.findById(request.applyId())
@@ -90,6 +93,7 @@ public class ApplyService {
                 .build();
     }
 
+    // 지원서 불러오기
     public LoadApplyResponseDTO loadApply(LoadApplyRequestDTO request) {
         Apply apply = applyRepository.findByStudentNumber(request.studentNumber())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLY_NOT_FOUND));
@@ -119,6 +123,7 @@ public class ApplyService {
                 .build();
     }
 
+    // 지원서 상태 처리
     private void handleApplyStatus(Apply apply, boolean isSubmit) {
         if (isSubmit) {
             applyStatusRepository.save(new ApplyStatus(apply.getStudentNumber()));
@@ -128,6 +133,7 @@ public class ApplyService {
         }
     }
 
+    // 지원서 개인정보 업데이트
     private void handleApplyInfo(Apply apply, ApplyRequestDTO request) {
         apply.updateName(request.name());
         apply.updateMajor(request.major());
@@ -136,6 +142,7 @@ public class ApplyService {
         apply.updateTrack(request.track());
     }
 
+    // 최초작성 상태에서 저장/제출 처리
     private void handleDraftStatus(Apply apply, ApplyRequestDTO request) {
         for (AnswerDTO answer : request.answers()) {
             Question question = questionRepository.findById(answer.questionId())
@@ -149,6 +156,7 @@ public class ApplyService {
         }
     }
 
+    // 임시저장 상태에서 저장/제출 처리
     private void handleSavedStatus(Apply apply, ApplyRequestDTO request) {
         for (AnswerDTO answer : request.answers()) {
             Answer savedAnswer = answerRepository.findByApplyApplyIdAndQuestionQuestionId(request.applyId(), answer.questionId())
@@ -167,6 +175,7 @@ public class ApplyService {
         }
     }
 
+    // 선택지 저장 처리
     private void saveAnswerChoices(AnswerDTO answer, Answer savedAnswer) {
         if (answer.choiceId() != null) {
             for (Long choiceId : answer.choiceId()) {

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -95,11 +95,11 @@ public class ApplyService {
 
     // 지원서 불러오기
     public LoadApplyResponseDTO loadApply(LoadApplyRequestDTO request) {
-        Apply apply = applyRepository.findByStudentNumber(request.studentNumber())
-                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLY_NOT_FOUND));
-        if (!passwordEncoder.matches(request.password(), apply.getPassword())) {
-            throw new BusinessException(ErrorCode.APPLY_INVALID_PASSWORD);
-        }
+        List<Apply> applies = applyRepository.findAllByStudentNumber(request.studentNumber());
+        Apply apply = applies.stream()
+                .filter(applyItem -> passwordEncoder.matches(request.password(), applyItem.getPassword()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.APPLY_INVALID_PASSWORD));
         return LoadApplyResponseDTO.builder()
                 .applyId(apply.getApplyId())
                 .status(apply.getStatus())


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #47 
 
## 🌱 작업 사항
- Service 메서드마다 주석 추가
- NOT NULL인 priority 필드 int 사용, nullable false 명시
- 지원서 불러오기 시, 학번을 List로 불러와서 비밀번호 일치하는 엔티티 사용 하도록 변경
  - 기존에는 Optional로 불러와 두개 이상 존재시 에러 발생했음
- N+1 관련 코드 개선
  -  Question 조회 시, Choice에 EntityGraph로 fetch join 적용
  - Apply 조회 시, Answer는  EntityGraph로 fetch join, 각 Answer에 대한 AnswerChoice는 BatchSize(5)로 조회
