### PR TITLE
[feat] 사용자 검색 기능

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/common/util/JamoUtil.java
+++ b/src/main/java/org/farmsystem/homepage/domain/common/util/JamoUtil.java
@@ -1,0 +1,99 @@
+package org.farmsystem.homepage.domain.common.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JamoUtil {
+
+    // 초성, 중성, 종성 배열
+    private static final String[] INITIALS = {
+            "ㄱ", "ㄲ", "ㄴ", "ㄷ", "ㄸ", "ㄹ", "ㅁ", "ㅂ", "ㅃ",
+            "ㅅ", "ㅆ", "ㅇ", "ㅈ", "ㅉ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"
+    };
+
+    private static final String[] MEDIALS_SIMPLE = {
+            "ㅏ", "ㅐ", "ㅑ", "ㅒ", "ㅓ", "ㅔ", "ㅕ", "ㅖ",
+            "ㅗ", "ㅘ", "ㅙ", "ㅚ", "ㅛ", "ㅜ", "ㅝ", "ㅞ", "ㅟ", "ㅠ",
+            "ㅡ", "ㅢ", "ㅣ"
+    };
+
+    private static final String[] FINALS_SIMPLE = {
+            "", "ㄱ", "ㄲ", "ㄳ", "ㄴ", "ㄵ", "ㄶ", "ㄷ", "ㄹ", "ㄺ",
+            "ㄻ", "ㄼ", "ㄽ", "ㄾ", "ㄿ", "ㅀ", "ㅁ", "ㅂ", "ㅄ", "ㅅ",
+            "ㅆ", "ㅇ", "ㅈ", "ㅊ", "ㅋ", "ㅌ", "ㅍ", "ㅎ"
+    };
+
+    // 합용 중성을 구성하는 단일 자모 분해 매핑
+    private static final Map<String, String[]> COMPOUND_MEDIALS = new HashMap<>();
+    static {
+        COMPOUND_MEDIALS.put("ㅘ", new String[]{"ㅗ", "ㅏ"});
+        COMPOUND_MEDIALS.put("ㅙ", new String[]{"ㅗ", "ㅐ"});
+        COMPOUND_MEDIALS.put("ㅚ", new String[]{"ㅗ", "ㅣ"});
+        COMPOUND_MEDIALS.put("ㅝ", new String[]{"ㅜ", "ㅓ"});
+        COMPOUND_MEDIALS.put("ㅞ", new String[]{"ㅜ", "ㅔ"});
+        COMPOUND_MEDIALS.put("ㅟ", new String[]{"ㅜ", "ㅣ"});
+        COMPOUND_MEDIALS.put("ㅢ", new String[]{"ㅡ", "ㅣ"});
+    }
+
+    // 합용 종성을 구성하는 단일 자모 분해 매핑
+    private static final Map<String, String[]> COMPOUND_FINALS = new HashMap<>();
+    static {
+        COMPOUND_FINALS.put("ㄳ", new String[]{"ㄱ", "ㅅ"});
+        COMPOUND_FINALS.put("ㄵ", new String[]{"ㄴ", "ㅈ"});
+        COMPOUND_FINALS.put("ㄶ", new String[]{"ㄴ", "ㅎ"});
+        COMPOUND_FINALS.put("ㄺ", new String[]{"ㄹ", "ㄱ"});
+        COMPOUND_FINALS.put("ㄻ", new String[]{"ㄹ", "ㅁ"});
+        COMPOUND_FINALS.put("ㄼ", new String[]{"ㄹ", "ㅂ"});
+        COMPOUND_FINALS.put("ㄽ", new String[]{"ㄹ", "ㅅ"});
+        COMPOUND_FINALS.put("ㄾ", new String[]{"ㄹ", "ㅌ"});
+        COMPOUND_FINALS.put("ㄿ", new String[]{"ㄹ", "ㅍ"});
+        COMPOUND_FINALS.put("ㅀ", new String[]{"ㄹ", "ㅎ"});
+        COMPOUND_FINALS.put("ㅄ", new String[]{"ㅂ", "ㅅ"});
+    }
+
+    /**
+     * 한글 문자열을 분해하여, 입력한 자모 순서대로 반환합니다.
+     * 예) "뷁" -> "ㅂㅜㅔㄹㄱ" (만약 음절 분해 결과가 compound 중성/종성이면 그 구성 단일 자모들을 순서대로 반환)
+     */
+    public static String convertToJamo(String input) {
+        if (input == null) return null;
+        StringBuilder sb = new StringBuilder();
+        for (char ch : input.toCharArray()) {
+            if (ch >= 0xAC00 && ch <= 0xD7A3) { // 한글 음절 범위
+                int syllableIndex = ch - 0xAC00;
+                int initialIndex = syllableIndex / (21 * 28);
+                int medialIndex = (syllableIndex % (21 * 28)) / 28;
+                int finalIndex = syllableIndex % 28;
+
+                // 초성 (항상 단일 자모)
+                String initial = INITIALS[initialIndex];
+                sb.append(initial);
+
+                // 중성 처리 (단일 자모라면 그대로, 합용이면 매핑 사용)
+                String medial = MEDIALS_SIMPLE[medialIndex];
+                if (COMPOUND_MEDIALS.containsKey(medial)) {
+                    for (String m : COMPOUND_MEDIALS.get(medial)) {
+                        sb.append(m);
+                    }
+                } else {
+                    sb.append(medial);
+                }
+
+                // 종성 처리 (존재할 경우)
+                if (finalIndex != 0) {
+                    String finalJamo = FINALS_SIMPLE[finalIndex];
+                    if (COMPOUND_FINALS.containsKey(finalJamo)) {
+                        for (String f : COMPOUND_FINALS.get(finalJamo)) {
+                            sb.append(f);
+                        }
+                    } else {
+                        sb.append(finalJamo);
+                    }
+                }
+            } else {
+                sb.append(ch);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -41,4 +41,10 @@ public class UserController {
         UserInfoResponseDTO updatedUserInfo = userService.updateUserInfo(userId, userInfoRequest);
         return SuccessResponse.ok(updatedUserInfo);
     }
+
+    // 사용자 검색 API
+    @GetMapping("/search")
+    public ResponseEntity<SuccessResponse<?>> searchUser(@RequestParam String query) {
+        return SuccessResponse.ok(userService.searchUser(query));
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -47,4 +47,10 @@ public class UserController {
     public ResponseEntity<SuccessResponse<?>> searchUser(@RequestParam String query) {
         return SuccessResponse.ok(userService.searchUser(query));
     }
+
+    // 사용자 검색 자동완성 API
+    @GetMapping("/suggest")
+    public ResponseEntity<SuccessResponse<?>> searchUserSuggest(@RequestParam String query) {
+        return SuccessResponse.ok(userService.searchUserSuggest(query));
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserSearchResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserSearchResponseDTO.java
@@ -1,0 +1,14 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import lombok.Builder;
+import org.farmsystem.homepage.domain.common.entity.Track;
+
+@Builder
+public record UserSearchResponseDTO(
+        Long userId,
+        String name,
+        String profileImageUrl,
+        Track track,
+        Integer generation
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.farmsystem.homepage.domain.common.entity.BaseTimeEntity;
 import org.farmsystem.homepage.domain.common.entity.Track;
+import org.farmsystem.homepage.domain.common.util.JamoUtil;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.List;
@@ -68,7 +69,14 @@ public class User extends BaseTimeEntity {
     @ColumnDefault("0")
     private int totalSeed;
 
+    @Column(nullable = false, length = 100)
+    private String nameJamo;
+
     @OneToMany(mappedBy = "user")
     private List<TrackHistory> trackHistories;
 
+    @PrePersist
+    public void initNameJamo() {
+        this.nameJamo = JamoUtil.convertToJamo(this.name);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User,Long>{
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
 
     Optional<User> findByStudentNumber(String studentNumber);
+
+    Optional<User> findByName(String name);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import org.farmsystem.homepage.domain.user.entity.SocialType;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long>{
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User,Long>{
     Optional<User> findByStudentNumber(String studentNumber);
 
     Optional<User> findByName(String name);
+
+    List<User> findByNameJamoStartsWith(String nameJamo);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserSaveResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserSearchResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
 import org.farmsystem.homepage.domain.user.entity.SocialType;
 import org.farmsystem.homepage.domain.user.entity.User;
@@ -85,6 +86,18 @@ public class UserService {
         return existedUser;
     }
 
+    public UserSearchResponseDTO searchUser(String query) {
+        User user = userRepository.findByName(query)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        return UserSearchResponseDTO.builder()
+                .userId(user.getUserId())
+                .name(user.getName())
+                .profileImageUrl(user.getProfileImageUrl())
+                .track(user.getTrack())
+                .generation(user.getGeneration())
+                .build();
+    }
+
     private User getExistedUser(String socialId, SocialType socialType) {
         return userRepository.findBySocialTypeAndSocialId(socialType, socialId).orElse(null);
     }
@@ -94,6 +107,7 @@ public class UserService {
             throw new BusinessException(USER_ALREADY_EXISTS);
         }
     }
+
     private User createUserFromPassedUser(String studentNumber, UserLoginRequestDTO userLoginRequest, String socialId, String imageUrl) {
         PassedApply passedUser = passedApplyRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(() -> new EntityNotFoundException(PASSED_USER_NOT_FOUND));

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -3,13 +3,11 @@ package org.farmsystem.homepage.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.apply.entity.PassedApply;
 import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
+import org.farmsystem.homepage.domain.common.util.JamoUtil;
 import org.farmsystem.homepage.domain.user.dto.request.UserInfoUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserSaveResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserSearchResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.*;
 import org.farmsystem.homepage.domain.user.entity.SocialType;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
@@ -22,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.farmsystem.homepage.global.error.ErrorCode.*;
 
@@ -96,6 +96,20 @@ public class UserService {
                 .track(user.getTrack())
                 .generation(user.getGeneration())
                 .build();
+    }
+
+    public List<UserSearchResponseDTO> searchUserSuggest(String query) {
+        List<User> userList = userRepository.findByNameJamoStartsWith(JamoUtil.convertToJamo(query));
+        return userList.stream()
+                .map(user -> UserSearchResponseDTO.builder()
+                        .userId(user.getUserId())
+                        .name(user.getName())
+                        .profileImageUrl(user.getProfileImageUrl())
+                        .track(user.getTrack())
+                        .generation(user.getGeneration())
+                        .build()
+                )
+                .collect(Collectors.toList());
     }
 
     private User getExistedUser(String socialId, SocialType socialType) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #35 
 
## 🌱 작업 사항
- 자모 분리 Util 클래스 추가
- User 엔티티에 이름 자모 필드 추가
- 사용자 검색 / 사용자 검색 추천(자동완성) API 구현

## 🌱 참고 사항
- 사용자 검색 기능(/search)은 필요없었는데 처음에 착각해서 만들어 놨으니 나중에 수정해서 쓰거나 하면 될 것 같습니다!
- Util 클래스는 해당 위치에 두면 될까요? 일단 뒀는데 옮기는게 나을 것 같으면 알려주세요
- 성능 관련해서는 클라이언트가 알아서 시간차이로 요청한다는 생각으로 하긴 했는데, 서버에서 뭔가 처리하는게 좋을까요?
