### PR TITLE
[fix] 스웨거 배포 주소 cors 에러 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/global/config/CorsConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package org.farmsystem.homepage.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -8,18 +9,39 @@ import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
+
+    @Value("${deployment.frontend.production}")
+    private String frontendProduction;
+
+    @Value("${deployment.frontend.test}")
+    private String frontendTest;
+
+    @Value("${deployment.backend.production}")
+    private String backendProduction;
+
+    @Value("${deployment.backend.test}")
+    private String backendTest;
 
     @Bean
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin("http://localhost:5173"); //프론트 주소
-        config.addAllowedOrigin("https://farmsystem.kr");
-        config.addAllowedOrigin("https://dev.farmsystem.kr");
+
+        // CORS 허용할 URL
+        List<String> allowedOrigins = Arrays.asList(
+                "http://localhost:5173",
+                frontendProduction,
+                frontendTest,
+                backendProduction,
+                backendTest
+        );
+        config.setAllowedOrigins(allowedOrigins);
+
         config.addAllowedHeader("*");
         config.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE", "PATCH"));
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #56 
 
## 🌱 작업 사항
corsConfig에 서버쪽 서브도메인 주소 추가

## 🌱 참고 사항
- yml업데이트
- 이전 pr에서 스웨거 https로 호스팅되게 수정했으나 여전히 GET을 제외한 http method사용하는 API에서 cors 문제 발생. 아래 블로그 우리랑 비슷한 상황인거 같아서 참고해서 수정했으나 개발 환경 테스트 필요 (로컬에서는 스웨거 cors 테스트할 수 있는 방법이,,,,)

(참고)
https://minseok-study.tistory.com/entry/JAVASPRING-BOOT-swagger-POST-PUT-PATCH-403-%EB%AC%B8%EC%A0%9C-%ED%8A%B8%EB%9F%AC%EB%B8%94-%EC%8A%88%ED%8C%85-springdoc
