### PR TITLE
[feat] news 이미지 추가

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsApi.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
-import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsDetailResponseDTO;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +25,7 @@ public interface AdminNewsApi {
                     description = "생성 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = NewsResponseDTO.class)
+                            schema = @Schema(implementation = NewsDetailResponseDTO.class)
                     )
             )
     })
@@ -39,7 +39,7 @@ public interface AdminNewsApi {
                     description = "수정 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = NewsResponseDTO.class)
+                            schema = @Schema(implementation = NewsDetailResponseDTO.class)
                     )
             ),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 소식 ID")

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/AdminNewsController.java
@@ -3,8 +3,7 @@ package org.farmsystem.homepage.domain.news.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.news.dto.request.NewsRequestDTO;
-import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
-import org.farmsystem.homepage.domain.news.entity.News;
+import org.farmsystem.homepage.domain.news.dto.response.NewsDetailResponseDTO;
 import org.farmsystem.homepage.domain.news.service.NewsService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
@@ -19,8 +18,7 @@ public class AdminNewsController implements AdminNewsApi{
 
     @PostMapping
     public ResponseEntity<SuccessResponse<?>> createNews(@RequestBody @Valid NewsRequestDTO request) {
-        News news = newsService.createNews(request);
-        NewsResponseDTO responseDto = new NewsResponseDTO(news.getNewsId(), news.getTitle(), news.getContent());
+        NewsDetailResponseDTO responseDto = newsService.createNews(request);
         return SuccessResponse.created(responseDto);
     }
 
@@ -28,8 +26,7 @@ public class AdminNewsController implements AdminNewsApi{
     public ResponseEntity<SuccessResponse<?>> updateNews(
             @PathVariable("newsId") Long newsId,
             @RequestBody @Valid NewsRequestDTO request) {
-        News updatedNews = newsService.updateNews(newsId, request);
-        NewsResponseDTO responseDto = new NewsResponseDTO(updatedNews.getNewsId(), updatedNews.getTitle(), updatedNews.getContent());
+        NewsDetailResponseDTO responseDto = newsService.updateNews(newsId, request);
         return SuccessResponse.ok(responseDto);
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsApi.java
@@ -8,7 +8,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsDetailResponseDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsListResponseDTO;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public interface NewsApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = NewsResponseDTO.class))
+                            array = @ArraySchema(schema = @Schema(implementation = NewsListResponseDTO.class))
                     )
             )
     })
@@ -39,7 +40,7 @@ public interface NewsApi {
                     description = "조회 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = NewsResponseDTO.class)
+                            schema = @Schema(implementation = NewsDetailResponseDTO.class)
                     )
             ),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 소식 ID")

--- a/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/controller/NewsController.java
@@ -1,15 +1,14 @@
 package org.farmsystem.homepage.domain.news.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.homepage.domain.news.dto.response.NewsResponseDTO;
-import org.farmsystem.homepage.domain.news.entity.News;
+import org.farmsystem.homepage.domain.news.dto.response.NewsListResponseDTO;
+import org.farmsystem.homepage.domain.news.dto.response.NewsDetailResponseDTO;
 import org.farmsystem.homepage.domain.news.service.NewsService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/news")
@@ -20,20 +19,13 @@ public class NewsController implements NewsApi{
 
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getAllNews() {
-        List<News> newsList = newsService.getAllNews();
-        List<NewsResponseDTO> dtoList = newsList.stream()
-                .map(news -> new NewsResponseDTO(
-                        news.getNewsId(),
-                        news.getTitle(),
-                        news.getContent()))
-                .collect(Collectors.toList());
+        List<NewsListResponseDTO> dtoList = newsService.getAllNews();
         return SuccessResponse.ok(dtoList);
     }
 
     @GetMapping("/{newsId}")
     public ResponseEntity<SuccessResponse<?>> getNewsById(@PathVariable("newsId") Long newsId) {
-        News news = newsService.getNewsById(newsId);
-        NewsResponseDTO responseDto = new NewsResponseDTO(news.getNewsId(), news.getTitle(), news.getContent());
+        NewsDetailResponseDTO responseDto = newsService.getNewsById(newsId);
         return SuccessResponse.ok(responseDto);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
@@ -1,4 +1,5 @@
 package org.farmsystem.homepage.domain.news.dto.request;
 
+import java.util.List;
 
-public record NewsRequestDTO(String title, String content) { }
+public record NewsRequestDTO(String title, String content, String thumbnailUrl, List<String> imageUrls) { }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
@@ -1,0 +1,5 @@
+package org.farmsystem.homepage.domain.news.dto.response;
+
+import java.util.List;
+
+public record NewsDetailResponseDTO(Long newsId, String title, String thumbnailUrl, String content, List<String> imageUrls) { }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
@@ -1,0 +1,3 @@
+package org.farmsystem.homepage.domain.news.dto.response;
+
+public record NewsListResponseDTO(Long newsId, String title, String thumbnailUrl) { }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsResponseDTO.java
@@ -1,5 +1,0 @@
-package org.farmsystem.homepage.domain.news.dto.response;
-
-
-public record NewsResponseDTO(Long newsId, String title, String content) { }
-

--- a/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/entity/News.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.farmsystem.homepage.domain.common.entity.BaseTimeEntity;
 
+import java.util.List;
+
 @Getter
 @Entity
 @Table(name = "news")
@@ -22,15 +24,26 @@ public class News extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Column(nullable = false)
+    private String thumbnailUrl;
+
+    @ElementCollection
+    @CollectionTable(name = "news_images", joinColumns = @JoinColumn(name = "news_id"))
+    @Column(name = "image_url")
+    private List<String> imageUrls;
+
     @Builder
-    public News(String title, String content) {
+    public News(String title, String content, String thumbnailUrl, List<String> imageUrls) {
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.imageUrls = imageUrls;
     }
 
-    public void updateTitleAndContent(String title, String content) {
+    public void updateNews(String title, String content, String thumbnailUrl, List<String> imageUrls) {
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
+        this.imageUrls = imageUrls;
     }
-
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #89 
 
## 🌱 작업 사항
- 썸네일 이미지 추가
- 본문 이미지들 추가

## 🌱 참고 사항
- 전체 조회용 NewsListResponseDTO, 단일 조회용 NewsDetailResponseDTO 분리
- 소식 관련 컬럼 전부 수정할 수 있도록 updateNews로 변경
