### PR TITLE
[fix] #101 지원서 상세 확인 시 제출 트랙의 답변만 반환하도록 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/SubmittedApplyResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/dto/response/SubmittedApplyResponseDTO.java
@@ -1,0 +1,49 @@
+package org.farmsystem.homepage.domain.apply.dto.response;
+
+import lombok.Builder;
+import org.farmsystem.homepage.domain.apply.dto.AnswerDTO;
+import org.farmsystem.homepage.domain.apply.entity.Apply;
+import org.farmsystem.homepage.domain.apply.entity.ApplyStatusEnum;
+import org.farmsystem.homepage.domain.common.entity.Track;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record SubmittedApplyResponseDTO(
+        Long applyId,
+        ApplyStatusEnum status,
+        LocalDateTime updatedAt,
+        String name,
+        String major,
+        String studentNumber,
+        String phoneNumber,
+        String email,
+        Track track,
+        List<AnswerDTO> answers
+) {
+    public static SubmittedApplyResponseDTO from(Apply apply) {
+        return SubmittedApplyResponseDTO.builder()
+                .applyId(apply.getApplyId())
+                .status(apply.getStatus())
+                .updatedAt(apply.getUpdatedAt())
+                .name(apply.getName())
+                .major(apply.getMajor())
+                .studentNumber(apply.getStudentNumber())
+                .phoneNumber(apply.getPhoneNumber())
+                .email(apply.getEmail())
+                .track(apply.getTrack())
+                .answers(apply.getAnswers().stream()
+                        .filter(answer -> answer.getQuestion().getTrack() == apply.getTrack())
+                        .map(answer -> AnswerDTO.builder()
+                                .questionId(answer.getQuestion().getQuestionId())
+                                .content(answer.getContent())
+                                .choiceId(answer.getAnswerChoices().stream()
+                                        .map(answerChoice -> answerChoice.getChoice().getChoiceId())
+                                        .collect(Collectors.toList()))
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/apply/service/ApplyService.java
@@ -5,10 +5,7 @@ import org.farmsystem.homepage.domain.apply.dto.*;
 import org.farmsystem.homepage.domain.apply.dto.request.ApplyRequestDTO;
 import org.farmsystem.homepage.domain.apply.dto.request.CreateApplyRequestDTO;
 import org.farmsystem.homepage.domain.apply.dto.request.LoadApplyRequestDTO;
-import org.farmsystem.homepage.domain.apply.dto.response.ApplyListResponseDTO;
-import org.farmsystem.homepage.domain.apply.dto.response.ApplyResponseDTO;
-import org.farmsystem.homepage.domain.apply.dto.response.CreateApplyResponseDTO;
-import org.farmsystem.homepage.domain.apply.dto.response.LoadApplyResponseDTO;
+import org.farmsystem.homepage.domain.apply.dto.response.*;
 import org.farmsystem.homepage.domain.apply.entity.*;
 import org.farmsystem.homepage.domain.apply.repository.*;
 import org.farmsystem.homepage.domain.common.entity.Track;
@@ -103,10 +100,10 @@ public class ApplyService {
     }
 
     // 관리자 - 지원서 상세
-    public LoadApplyResponseDTO getApply(Long applyId) {
+    public SubmittedApplyResponseDTO getApply(Long applyId) {
         Apply apply = applyRepository.findById(applyId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.APPLY_NOT_FOUND));
-        return LoadApplyResponseDTO.from(apply);
+        return SubmittedApplyResponseDTO.from(apply);
     }
 
     // 지원서 상태 처리


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #101 
 
## 🌱 작업 사항
지원서 상세 확인 시 제출 트랙의 답변만 반환하도록 수정
- SubmittedApplyResponseDTO 생성
- filter() 통해 answer의 track 이 apply의 track과 같은 answer만 response에 포함