### PR TITLE
[chore] BE 레포 자동 리뷰어 지정

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# BE 리뷰어 지정
+* @saokiritoni @floreo1242 @hysong4u


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #108
 
## 🌱 작업 사항
- BE 레포 자동 리뷰어 지정

## 🌱 참고 사항
- 하위팀이 안 만들어져서 일단은 개인 아이디로 지정했는데 나중에는 파트별 하위팀 만들어서 팀 멘션&팀 리뷰어 관리하면 좋지않을까라는 생각!
