### PR TITLE
[feat] 씨앗 & 랭킹 관련 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 
     //csv
     implementation 'org.apache.commons:commons-csv:1.10.0'
+
+    //spring cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
@@ -6,8 +6,10 @@ import org.farmsystem.homepage.domain.cheer.dto.response.CheerResponseDTO;
 import org.farmsystem.homepage.domain.cheer.dto.response.PagingCheerListResponseDTO;
 import org.farmsystem.homepage.domain.cheer.entity.Cheer;
 import org.farmsystem.homepage.domain.cheer.repository.CheerRepository;
+import org.farmsystem.homepage.domain.user.entity.SeedEventType;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.domain.user.service.DailySeedService;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.farmsystem.homepage.global.error.exception.BusinessException;
 import org.springframework.data.domain.Page;
@@ -25,6 +27,7 @@ public class CheerService {
 
     private final CheerRepository cheerRepository;
     private final UserRepository userRepository;
+    private final DailySeedService dailySeedService;
 
     // 응원 리스트 조회 (페이징)
     public PagingCheerListResponseDTO getAllCheer(Pageable pageable) {
@@ -49,6 +52,8 @@ public class CheerService {
                 .tag(request.tag())
                 .build();
         Cheer savedCheer = cheerRepository.save(cheer);
+
+        dailySeedService.earnSeed(cheerer.getUserId(), SeedEventType.CHEER);
         return CheerResponseDTO.from(savedCheer);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogService.java
@@ -6,8 +6,10 @@ import org.farmsystem.homepage.domain.farmingLog.dto.FarmingLogResponseDTO;
 import org.farmsystem.homepage.domain.farmingLog.entity.FarmingLog;
 import org.farmsystem.homepage.domain.farmingLog.repository.FarmingLogLikeRepository;
 import org.farmsystem.homepage.domain.farmingLog.repository.FarmingLogRepository;
+import org.farmsystem.homepage.domain.user.entity.SeedEventType;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.domain.user.service.DailySeedService;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.farmsystem.homepage.global.error.exception.BusinessException;
 import org.springframework.data.domain.Page;
@@ -22,6 +24,7 @@ public class FarmingLogService {
     private final FarmingLogRepository farmingLogRepository;
     private final FarmingLogLikeRepository farmingLogLikeRepository;
     private final UserRepository userRepository;
+    private final DailySeedService dailySeedService;
 
     private FarmingLogResponseDTO mapToFarmingLogResponse(FarmingLog farmingLog, User currentUser) {
         boolean isLiked = farmingLogLikeRepository.existsByUserAndFarmingLog(currentUser, farmingLog);
@@ -61,6 +64,8 @@ public class FarmingLogService {
                 .build();
 
         farmingLogRepository.save(farmingLog);
+
+        dailySeedService.earnSeed(userId, SeedEventType.FARMING_LOG);
         return FarmingLogResponseDTO.from(farmingLog, userId, false, 0);
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserApi.java
@@ -12,9 +12,13 @@ import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.OtherUserInfoResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserRankListResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Tag(name = "사용자 API", description = "사용자 관련 API")
 public interface UserApi {
@@ -83,4 +87,35 @@ public interface UserApi {
             @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
     })
     ResponseEntity<SuccessResponse<?>> getOtherUserInfo(Long userId);
+
+    @Operation(
+            summary = "출석하기",
+            description = "사용자가 출석을 하는 API입니다.  \n" +
+                    " 출석 후 1개의 씨앗이 적립됩니다. 출석 씨앗 적립은 하루에 한 번만 가능합니다. ",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "출석 성공", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
+    })
+    @PostMapping("/attendance")
+    ResponseEntity<SuccessResponse<?>> attend(Long userId);
+
+    @Operation(
+            summary = "사용자 랭킹 조회",
+            description = "사용자의 랭킹을 조회하는 API입니다. 사용자 자신과 전체 랭킹을 반환합니다.  \n" +
+                    "랭킹은 0시 기준으로 갱신됩니다. ",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "랭킹 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UserRankListResponseDTO.class)
+                    )),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
+    })
+    @GetMapping("/ranking")
+    ResponseEntity<SuccessResponse<?>> getUserRanking(Long userId);
 }
+

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -5,9 +5,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.response.OtherUserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.*;
+import org.farmsystem.homepage.domain.user.service.UserRankingService;
 import org.farmsystem.homepage.domain.user.service.UserService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class UserController implements UserApi {
     private final UserService userService;
+    private final UserRankingService userRankingService;
 
     // 사용자 회원 인증 API
     @PostMapping("/verify")
@@ -59,5 +59,12 @@ public class UserController implements UserApi {
     @GetMapping("/suggest")
     public ResponseEntity<SuccessResponse<?>> searchUserSuggest(@RequestParam String query) {
         return SuccessResponse.ok(userService.searchUserSuggest(query));
+    }
+
+    // 사용자 랭킹
+    @GetMapping("/ranking")
+    public ResponseEntity<SuccessResponse<?>> getUserRanking(@AuthenticationPrincipal Long userId) {
+        UserRankListResponseDTO userRankList = userRankingService.getDailyRanking(userId);
+        return SuccessResponse.ok(userRankList);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -61,14 +61,14 @@ public class UserController implements UserApi {
         return SuccessResponse.ok(userService.searchUserSuggest(query));
     }
 
-    // 출석
+    // 출석 API
     @PostMapping("/attendance")
     public ResponseEntity<SuccessResponse<?>> attend(@AuthenticationPrincipal Long userId) {
         userService.attend(userId);
         return SuccessResponse.ok(null);
     }
 
-    // 사용자 랭킹
+    // 사용자 랭킹 조회 API
     @GetMapping("/ranking")
     public ResponseEntity<SuccessResponse<?>> getUserRanking(@AuthenticationPrincipal Long userId) {
         UserRankListResponseDTO userRankList = rankingService.getDailyRanking(userId);

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.*;
-import org.farmsystem.homepage.domain.user.service.UserRankingService;
+import org.farmsystem.homepage.domain.user.service.RankingService;
 import org.farmsystem.homepage.domain.user.service.UserService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class UserController implements UserApi {
     private final UserService userService;
-    private final UserRankingService userRankingService;
+    private final RankingService rankingService;
 
     // 사용자 회원 인증 API
     @PostMapping("/verify")
@@ -61,10 +61,17 @@ public class UserController implements UserApi {
         return SuccessResponse.ok(userService.searchUserSuggest(query));
     }
 
+    // 출석
+    @PostMapping("/attendance")
+    public ResponseEntity<SuccessResponse<?>> attend(@AuthenticationPrincipal Long userId) {
+        userService.attend(userId);
+        return SuccessResponse.ok(null);
+    }
+
     // 사용자 랭킹
     @GetMapping("/ranking")
     public ResponseEntity<SuccessResponse<?>> getUserRanking(@AuthenticationPrincipal Long userId) {
-        UserRankListResponseDTO userRankList = userRankingService.getDailyRanking(userId);
+        UserRankListResponseDTO userRankList = rankingService.getDailyRanking(userId);
         return SuccessResponse.ok(userRankList);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserRankListResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserRankListResponseDTO.java
@@ -1,0 +1,9 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import java.util.List;
+
+public record UserRankListResponseDTO(
+        UserRankResponseDTO myRank,
+        List<UserRankResponseDTO> userRankList
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserRankResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/UserRankResponseDTO.java
@@ -1,0 +1,26 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import org.farmsystem.homepage.domain.common.entity.Track;
+import org.farmsystem.homepage.domain.user.entity.User;
+
+public record UserRankResponseDTO(
+        Integer rank,
+        long userId,
+        String profileImageUrl,
+        String name,
+        Integer generation,
+        Track track,
+        Integer totalSeed
+) {
+    public static UserRankResponseDTO from(Integer rank, User user) {
+        return new UserRankResponseDTO(
+                rank,
+                user.getUserId(),
+                user.getProfileImageUrl(),
+                user.getName(),
+                user.getGeneration(),
+                user.getTrack(),
+                user.getTotalSeed()
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/DailySeed.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/DailySeed.java
@@ -1,0 +1,44 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.farmsystem.homepage.domain.common.entity.BaseTimeEntity;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "daily_seed")
+@Entity
+public class DailySeed extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long dailySeedId;
+
+    @ColumnDefault("false")
+    private boolean isAttendance;
+
+    @ColumnDefault("false")
+    private boolean isCheer;
+
+    @ColumnDefault("false")
+    private boolean isFarminglog;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public DailySeed(User user) {
+        this.user = user;
+    }
+
+    public void updateAttendance() {this.isAttendance = true;}
+    public void updateCheer() {this.isCheer = true;}
+    public void updateFarminglog() {this.isFarminglog = true;}
+
+    public void reset() {
+        this.isAttendance = false;
+        this.isCheer = false;
+        this.isFarminglog = false;
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/SeedEventType.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/SeedEventType.java
@@ -1,0 +1,14 @@
+package org.farmsystem.homepage.domain.user.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SeedEventType {
+    ATTENDANCE(1),   // 출석 1개
+    CHEER(2),        // 응원 2개
+    FARMING_LOG(5);  // 파밍로그 5개
+
+    private final int seedAmount;
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/entity/User.java
@@ -109,4 +109,8 @@ public class User extends BaseTimeEntity {
         if (user.getGithubAccount() != null) this.githubAccount = user.getGithubAccount();
     }
 
+    public void addTotalSeed(int seedAmount) {
+        this.totalSeed += seedAmount;
+    }
+
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/DailySeedRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/DailySeedRepository.java
@@ -1,0 +1,11 @@
+package org.farmsystem.homepage.domain.user.repository;
+
+import org.farmsystem.homepage.domain.user.entity.DailySeed;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DailySeedRepository extends JpaRepository<DailySeed, Long> {
+    Optional<DailySeed> findByUser(User user);
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/repository/UserRepository.java
@@ -23,6 +23,8 @@ public interface UserRepository extends JpaRepository<User,Long>{
 
     Page<User> findAll(Pageable pageable);
 
+    List<User> findAllByOrderByTotalSeedDesc();
+
     @Query(value = "SELECT * FROM user WHERE is_deleted = true", nativeQuery = true)
     Page<User> findDeletedUsers(Pageable pageable);
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
@@ -26,6 +26,7 @@ public class DailySeedService {
     private final UserRepository userRepository;
 
     //TODO : 적립 필요한 이벤트에 earnSeed 함수 호출 추가하기
+    // 예 : dailySeedService.earnSeed(userId, SeedEventType.ATTENDANCE);
     @Transactional
     public void earnSeed(Long userId, SeedEventType eventType) {
         User user = userRepository.findById(userId)

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
@@ -1,0 +1,72 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.homepage.domain.user.entity.DailySeed;
+import org.farmsystem.homepage.domain.user.entity.SeedEventType;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.farmsystem.homepage.domain.user.repository.DailySeedRepository;
+import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailySeedService {
+
+    private final DailySeedRepository dailySeedRepository;
+    private final UserRepository userRepository;
+
+    //TODO : 적립 필요한 이벤트에 earnSeed 함수 호출 추가하기
+    @Transactional
+    public void earnSeed(Long userId, SeedEventType eventType) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        DailySeed dailySeed = dailySeedRepository.findByUser(user)
+                .orElseGet(() -> new DailySeed(user));
+
+        handleSeedEvent(dailySeed, eventType, user);
+
+        dailySeedRepository.save(dailySeed);
+        userRepository.save(user);
+    }
+
+    // 중복 등록 방지
+    private void handleSeedEvent(DailySeed dailySeed, SeedEventType eventType, User user) {
+        switch (eventType) {
+            case ATTENDANCE:
+                if (dailySeed.isAttendance()) return;
+                dailySeed.updateAttendance();
+                user.addTotalSeed(eventType.getSeedAmount());
+                break;
+            case CHEER:
+                if (dailySeed.isCheer()) return;
+                dailySeed.updateCheer();
+                user.addTotalSeed(eventType.getSeedAmount());
+                break;
+            case FARMING_LOG:
+                if (dailySeed.isFarminglog()) return;
+                dailySeed.updateFarminglog();
+                user.addTotalSeed(eventType.getSeedAmount());
+                break;
+        }
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void resetDailySeed() {
+        log.info("씨앗 적립 초기화 스케줄링 실행 : {}", LocalDate.now());
+        dailySeedRepository.findAll().forEach(dailySeed -> {
+            dailySeed.reset();
+        });
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/RankingCacheService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/RankingCacheService.java
@@ -10,6 +10,7 @@ import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,6 +19,7 @@ import java.util.List;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class RankingCacheService {
 
     private final UserRepository userRepository;
@@ -43,17 +45,15 @@ public class RankingCacheService {
         return rankList;
     }
 
-
     // 자정마다 랭킹 업데이트
+    @Transactional
     @Scheduled(cron = "0 0 0 * * *")
     @CachePut(value = "dailySeedRanking", key = "'all'")
     public List<UserRankResponseDTO> updateDailyRanking() {
 
-        LocalDate now = LocalDate.now();
-        log.info("씨앗 랭킹 갱신 : " + now);
+        log.info("씨앗 랭킹 업데이트 스케줄링 : {}", LocalDate.now());
 
         cacheManager.getCache("dailySeedRanking").evict("all");
-
         return getRankingList();
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/RankingCacheService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/RankingCacheService.java
@@ -1,0 +1,60 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.homepage.domain.user.dto.response.UserRankResponseDTO;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RankingCacheService {
+
+    private final UserRepository userRepository;
+    private final CacheManager cacheManager;
+
+    // 랭킹 조회
+    @Cacheable(value = "dailySeedRanking", key = "'all'")
+    public List<UserRankResponseDTO> getRankingList() {
+        List<User> rankedUsers = userRepository.findAllByOrderByTotalSeedDesc();
+
+        List<UserRankResponseDTO> rankList = new ArrayList<>();
+        int rank = 1, prevSeed = -1, actualRank = 1;
+
+        for (User user : rankedUsers) {
+            if (user.getTotalSeed() != prevSeed) {
+                actualRank = rank;
+            }
+            rankList.add(UserRankResponseDTO.from(actualRank, user));;
+
+            prevSeed = user.getTotalSeed();
+            rank++;
+        }
+        return rankList;
+    }
+
+
+    // 자정마다 랭킹 업데이트
+    @Scheduled(cron = "0 0 0 * * *")
+    @CachePut(value = "dailySeedRanking", key = "'all'")
+    public List<UserRankResponseDTO> updateDailyRanking() {
+
+        LocalDate now = LocalDate.now();
+        log.info("씨앗 랭킹 갱신 : " + now);
+
+        cacheManager.getCache("dailySeedRanking").evict("all");
+
+        return getRankingList();
+    }
+
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/RankingService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/RankingService.java
@@ -1,26 +1,25 @@
 package org.farmsystem.homepage.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.farmsystem.homepage.domain.user.dto.response.UserRankListResponseDTO;
 import org.farmsystem.homepage.domain.user.dto.response.UserRankResponseDTO;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
 import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
-public class UserRankingService {
+@Transactional(readOnly = true)
+public class RankingService {
 
     private final UserRepository userRepository;
     private final RankingCacheService rankingCacheService;
-
 
     // 랭킹 조회
     public UserRankListResponseDTO getDailyRanking(Long userId) {

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserRankingService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserRankingService.java
@@ -1,0 +1,45 @@
+package org.farmsystem.homepage.domain.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.homepage.domain.user.dto.response.UserRankListResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.UserRankResponseDTO;
+import org.farmsystem.homepage.domain.user.entity.User;
+import org.farmsystem.homepage.domain.user.repository.UserRepository;
+import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static org.farmsystem.homepage.global.error.ErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserRankingService {
+
+    private final UserRepository userRepository;
+    private final RankingCacheService rankingCacheService;
+
+
+    // 랭킹 조회
+    public UserRankListResponseDTO getDailyRanking(Long userId) {
+
+        UserRankResponseDTO myRank = getMyRank(userId);
+        List<UserRankResponseDTO> rankList = rankingCacheService.getRankingList();
+
+        return new UserRankListResponseDTO(myRank, rankList);
+    }
+
+    // 본인 랭킹
+    private UserRankResponseDTO getMyRank(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        return rankingCacheService.getRankingList().stream()
+                .filter(userRankResponseDTO -> userRankResponseDTO.userId() == user.getUserId())
+                .findFirst()
+                .orElse(null);
+    }
+}
+

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -4,17 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.apply.entity.PassedApply;
 import org.farmsystem.homepage.domain.apply.repository.PassedApplyRepository;
 import org.farmsystem.homepage.domain.common.dto.response.PageResponseDTO;
-import org.farmsystem.homepage.domain.common.util.JamoUtil;
 import org.farmsystem.homepage.domain.common.entity.Track;
-import org.farmsystem.homepage.domain.user.dto.request.UserLoginRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserSaveResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserSearchResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.common.util.JamoUtil;
 import org.farmsystem.homepage.domain.user.dto.request.*;
 import org.farmsystem.homepage.domain.user.dto.response.*;
+import org.farmsystem.homepage.domain.user.entity.SeedEventType;
 import org.farmsystem.homepage.domain.user.entity.SocialType;
 import org.farmsystem.homepage.domain.user.entity.TrackHistory;
 import org.farmsystem.homepage.domain.user.entity.User;
@@ -40,6 +34,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PassedApplyRepository passedApplyRepository;
     private final TrackHistoryRepository trackHistoryRepository;
+    private final DailySeedService dailySeedService;
 
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
         PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
@@ -182,5 +177,13 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
         return OtherUserInfoResponseDTO.from(user);
+    }
+
+    //출석하기
+    @Transactional
+    public void attend(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+        dailySeedService.earnSeed(userId, SeedEventType.ATTENDANCE);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/global/config/CacheConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/CacheConfig.java
@@ -1,0 +1,16 @@
+package org.farmsystem.homepage.global.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager("dailySeedRanking");
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/global/config/SchedulingConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package org.farmsystem.homepage.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #63 
 
## 🌱 작업 사항
- 출석 하기 API 구현
- 씨앗 적립 로직 구현 (해당하는 이벤트에 씨앗 적립 로직 추가 완료)
   - 적립 관련 여부를 저장할 수 있는 엔티티 (DailySeed) 추가
   - 0시 적립 초기화 스케줄링 
   - 적립 관련한 이벤트의 요청 횟수를 막아두지는 않았습니다.(응원이나 파밍로그 같은 경우 하루에 여러 번 할 수 있도록)  
   -  => 근데 출석 같은 경우 여러 번 요청되는 게 어색할 거 같아 이건 프론트 상의 처리가 필요할 듯
   - 요청은 여러번 되어도 하루에 적립은 1번만 됩니다
- 랭킹 관련 API 구현 
   - 0시 랭킹 업데이트 스케줄링
   - 조회 마다 매번 DB 정렬하는게 성능상 안 좋을 거 같아서  랭킹 조회 구현 방식에 대해 좀 고민했는데 Redis랑 로컬캐시 중 고민하다 로컬 캐시 적용했습니다. 시간 찍어보니 캐싱 적용 했을 때랑 안 했을 때10배 넘게 차이나더라는 (나중에 규모 좀 커지면 Redis Sorted Set인가 써도 좋을 듯!)
   - 같은 클래스 내에 랭킹 관련 로직과 캐싱 로직을 함께 넣었더니 작동이 안돼서 클래스 `RankingService` , `RankingCacheService` 분리했습니다 (원인 찾아보니 스프링에서  @Cacheable 어노테이션은 AOP 방식으로 프록시 객체를 통해 적용되는데, 같은 클래스 내에서 메서드 호출 시 내부 메서드가 프록시를 통해 가로채지 못해 캐싱이 처리 안될 수 있다고 함)

## 🌱 참고 사항
- yml 업데이트 있습니다 (기본 캐싱 레디스 말고 로컬로 연결되게 추가)
