### PR TITLE
[feat] #121 cheered와 cheerer가 같을 경우 에러 발생

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/cheer/controller/CheerApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/cheer/controller/CheerApi.java
@@ -42,6 +42,7 @@ public interface CheerApi {
                             mediaType = "application/json",
                             schema = @Schema(implementation = CheerResponseDTO.class)
                     )),
+            @ApiResponse(responseCode = "400", description = "자기 자신 응원"),
             @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
     })
     ResponseEntity<SuccessResponse<?>> createCheer(@RequestBody @Valid CheerRequestDTO request);

--- a/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
@@ -41,6 +41,9 @@ public class CheerService {
     // 응원 등록
     @Transactional
     public CheerResponseDTO createCheer(CheerRequestDTO request) {
+        if (request.cheererId().equals(request.cheeredId())) {
+            throw new BusinessException(ErrorCode.SAME_CHEERER_CHEERED);
+        }
         User cheerer = userRepository.findById(request.cheererId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         User cheered = userRepository.findById(request.cheeredId())

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -123,7 +123,12 @@ public enum ErrorCode {
      * Notification Error
      */
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
-    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "알림에 대한 권한이 없습니다.")
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "알림에 대한 권한이 없습니다."),
+
+    /**
+     * Cheer Error
+     */
+    SAME_CHEERER_CHEERED(HttpStatus.BAD_REQUEST, "자기 자신을 응원할 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #121 
 
## 🌱 작업 사항
에러코드 SAME_CHEERED_CHEERED 추가
cheererId와 cheeredId가 같을 때 에러 발생
API 문서에 실패 예시 추가

## 🌱 참고 사항
프론트에서도 응원할 사용자 검색 시 자기 자신 안나오게 걸러주면 좋을 것 같습니다!!
