### PR TITLE
[feat] 알림 전송 코드 추가

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/cheer/controller/CheerController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/cheer/controller/CheerController.java
@@ -27,4 +27,10 @@ public class CheerController implements CheerApi {
     public ResponseEntity<SuccessResponse<?>> createCheer(@RequestBody @Valid CheerRequestDTO request) {
         return SuccessResponse.created(cheerService.createCheer(request));
     }
+
+    // 특정 응원 조회
+    @GetMapping("/{cheerId}")
+    public ResponseEntity<SuccessResponse<?>> getCheerById(@PathVariable Long cheerId) {
+        return SuccessResponse.ok(cheerService.getCheer(cheerId));
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/cheer/service/CheerService.java
@@ -64,4 +64,11 @@ public class CheerService {
         dailySeedService.earnSeed(cheerer.getUserId(), SeedEventType.CHEER);
         return CheerResponseDTO.from(savedCheer);
     }
+
+    // 특정 응원 조회
+    public CheerResponseDTO getCheer(Long cheerId) {
+        Cheer cheer = cheerRepository.findById(cheerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CHEER_NOT_FOUND));
+        return CheerResponseDTO.from(cheer);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogLikeService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogLikeService.java
@@ -5,12 +5,16 @@ import org.farmsystem.homepage.domain.farmingLog.entity.FarmingLog;
 import org.farmsystem.homepage.domain.farmingLog.entity.FarmingLogLike;
 import org.farmsystem.homepage.domain.farmingLog.repository.FarmingLogLikeRepository;
 import org.farmsystem.homepage.domain.farmingLog.repository.FarmingLogRepository;
+import org.farmsystem.homepage.domain.notification.event.FarmingLogLikedEvent;
 import org.farmsystem.homepage.domain.user.entity.User;
 import org.farmsystem.homepage.domain.user.repository.UserRepository;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.farmsystem.homepage.global.error.exception.BusinessException;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +22,7 @@ public class FarmingLogLikeService {
     private final FarmingLogRepository farmingLogRepository;
     private final FarmingLogLikeRepository farmingLogLikeRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
     public void toggleLike(Long userId, Long farmingLogId) {
@@ -27,15 +32,31 @@ public class FarmingLogLikeService {
         FarmingLog farmingLog = farmingLogRepository.findById(farmingLogId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FARMING_LOG_NOT_FOUND));
 
-        farmingLogLikeRepository.findByUserAndFarmingLog(user, farmingLog)
-                .ifPresentOrElse(
-                        farmingLogLikeRepository::delete,
-                        () -> farmingLogLikeRepository.save(
-                                FarmingLogLike.builder()
-                                        .user(user)
-                                        .farmingLog(farmingLog)
-                                        .build()
-                        )
-                );
+        boolean isLikeAdded;
+        Optional<FarmingLogLike> existingLike = farmingLogLikeRepository.findByUserAndFarmingLog(user, farmingLog);
+        if (existingLike.isPresent()) {
+            farmingLogLikeRepository.delete(existingLike.get());
+            isLikeAdded = false;
+        } else {
+            farmingLogLikeRepository.save(
+                    FarmingLogLike.builder()
+                            .user(user)
+                            .farmingLog(farmingLog)
+                            .build()
+            );
+            isLikeAdded = true;
+        }
+        // 좋아요가 추가된 경우에만 이벤트 전송
+        if (isLikeAdded) {
+            FarmingLogLikedEvent event = new FarmingLogLikedEvent(
+                    farmingLog.getUser().getUserId(),   // 알림을 받을 사용자(파밍로그 작성자) 번호
+                    user.getGeneration(),               // 좋아요를 한 사용자 기수
+                    user.getTrack(),                    // 좋아요를 한 사용자 트랙
+                    user.getName(),                     // 좋아요를 한 사용자 이름
+                    farmingLog.getTitle(),              // 관련된 파밍로그 제목
+                    farmingLog.getFarmingLogId()        // 관련된 파밍로그 번호
+            );
+            applicationEventPublisher.publishEvent(event);
+        }
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/notification/controller/NotificationApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/controller/NotificationApi.java
@@ -7,7 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import org.farmsystem.homepage.domain.notification.dto.NotificationResponseDto;
+import org.farmsystem.homepage.domain.notification.dto.NotificationResponseDTO;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -40,7 +40,7 @@ public interface NotificationApi {
             @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공",
                     content = @Content(
                             mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = NotificationResponseDto.class))
+                            array = @ArraySchema(schema = @Schema(implementation = NotificationResponseDTO.class))
                     )
             ),
             @ApiResponse(responseCode = "403", description = "알림에 대한 권한 없음", content = @Content),

--- a/src/main/java/org/farmsystem/homepage/domain/notification/dto/NotificationResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/dto/NotificationResponseDTO.java
@@ -7,7 +7,7 @@ import org.farmsystem.homepage.domain.notification.entity.NotificationType;
 import java.time.LocalDateTime;
 
 @Builder
-public record NotificationResponseDto(
+public record NotificationResponseDTO(
         Long notificationId,
         NotificationType type,
         String title,
@@ -16,8 +16,8 @@ public record NotificationResponseDto(
         boolean isRead,
         LocalDateTime createdAt
 ) {
-    public static NotificationResponseDto from(Notification notification) {
-        return NotificationResponseDto.builder()
+    public static NotificationResponseDTO from(Notification notification) {
+        return NotificationResponseDTO.builder()
                 .notificationId(notification.getNotificationId())
                 .type(notification.getType())
                 .title(notification.getTitle())

--- a/src/main/java/org/farmsystem/homepage/domain/notification/event/CheerReceiveEvent.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/event/CheerReceiveEvent.java
@@ -1,0 +1,12 @@
+package org.farmsystem.homepage.domain.notification.event;
+
+import org.farmsystem.homepage.domain.common.entity.Track;
+
+public record CheerReceiveEvent(
+        Long cheeredId,
+        Integer CheererGeneration,
+        Track CheererTrack,
+        String CheererName,
+        Long cheerId
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/notification/event/FarmingLogLikedEvent.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/event/FarmingLogLikedEvent.java
@@ -1,0 +1,13 @@
+package org.farmsystem.homepage.domain.notification.event;
+
+import org.farmsystem.homepage.domain.common.entity.Track;
+
+public record FarmingLogLikedEvent(
+        Long receiverId,
+        Integer likerGeneration,
+        Track likerTrack,
+        String likerName,
+        String farmingLogTitle,
+        Long farmingLogId
+) {
+}

--- a/src/main/java/org/farmsystem/homepage/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/event/NotificationEventListener.java
@@ -12,14 +12,13 @@ public class NotificationEventListener {
 
     private final NotificationService notificationService;
 
-//    @EventListener
-//    public void handleCheerReceiveEvent(CheerReceiveEvent event) {
-//        // 제목, 메시지 등은 추후 변경
-//        String title = "새 응원 알림";
-//        String message = event.cheererName() + "님이 " + event.cheeredName() + "님을 응원했어요!";
-//        String targetUrl = "/cheer/" + event.cheerId();
-//
-//        // SSE를 통해 해당 사용자에게 알림 전송
-//        notificationService.sendNotification(event.cheeredId(), title, message, NotificationType.CHEER,  targetUrl);
-//    }
+    @EventListener
+    public void handleCheerReceiveEvent(CheerReceiveEvent event) {
+        String title = "새 응원 알림";
+        String message = event.CheererGeneration().toString() + " " + event.CheererTrack().toString() + " " + event.CheererName() + "님이 응원을 보냈습니다.";
+        String targetUrl = "/cheer/" + event.cheerId();
+
+        // SSE를 통해 해당 사용자에게 알림 전송
+        notificationService.sendNotification(event.cheeredId(), title, message, NotificationType.CHEER, targetUrl);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/event/NotificationEventListener.java
@@ -21,4 +21,12 @@ public class NotificationEventListener {
         // SSE를 통해 해당 사용자에게 알림 전송
         notificationService.sendNotification(event.cheeredId(), title, message, NotificationType.CHEER, targetUrl);
     }
+
+    @EventListener
+    public void handleFarmingLogLikedEvent(FarmingLogLikedEvent event) {
+        String title = "파밍로그 좋아요 알림";
+        String message = event.likerGeneration().toString() + " " + event.likerTrack().toString() + " " + event.likerName() + "님이 '" + event.farmingLogTitle() + "'에 공감하셨습니다.";
+        String targetUrl = "/farming-logs/" + event.farmingLogId();
+        notificationService.sendNotification(event.receiverId(), title, message, NotificationType.LIKE, targetUrl);
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/service/NotificationService.java
@@ -1,7 +1,7 @@
 package org.farmsystem.homepage.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
-import org.farmsystem.homepage.domain.notification.dto.NotificationResponseDto;
+import org.farmsystem.homepage.domain.notification.dto.NotificationResponseDTO;
 import org.farmsystem.homepage.domain.notification.entity.Notification;
 import org.farmsystem.homepage.domain.notification.entity.NotificationType;
 import org.farmsystem.homepage.domain.notification.repository.NotificationRepository;
@@ -78,12 +78,12 @@ public class NotificationService {
         notificationRepository.save(notification);
     }
 
-    public List<NotificationResponseDto> getNotifications(Long userId) {
+    public List<NotificationResponseDTO> getNotifications(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
         List<Notification> notifications = notificationRepository.findAllByUserOrderByCreatedAtDesc((user));
         return notifications.stream()
-                .map(NotificationResponseDto::from)
+                .map(NotificationResponseDTO::from)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
+++ b/src/main/java/org/farmsystem/homepage/global/error/ErrorCode.java
@@ -128,7 +128,8 @@ public enum ErrorCode {
     /**
      * Cheer Error
      */
-    SAME_CHEERER_CHEERED(HttpStatus.BAD_REQUEST, "자기 자신을 응원할 수 없습니다.")
+    SAME_CHEERER_CHEERED(HttpStatus.BAD_REQUEST, "자기 자신을 응원할 수 없습니다."),
+    CHEER_NOT_FOUND(HttpStatus.NOT_FOUND, "응원을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #126 
 
## 🌱 작업 사항
- 응원하기 등록, 파밍로그 좋아요 시 알림 이벤트 생성 및 전송
- 응원하기 개별 조회 기능 추가

## 🌱 참고 사항
- @saokiritoni  파밍로그 좋아요 토글 서비스에서 좋아요를 했을 때에만 알림이 가도록 하기 위해 코드 조금 수정했으니 확인해주세요!!
