### PR TITLE
[ feat ] 오늘의 씨앗 적립 현황 표시 & 토큰 재발급 API 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserApi.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
-import org.farmsystem.homepage.domain.user.dto.response.OtherUserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserInfoResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserRankListResponseDTO;
-import org.farmsystem.homepage.domain.user.dto.response.UserVerifyResponseDTO;
+import org.farmsystem.homepage.domain.user.dto.response.*;
 import org.farmsystem.homepage.global.common.SuccessResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -118,5 +115,22 @@ public interface UserApi {
     })
     @GetMapping("/ranking")
     ResponseEntity<SuccessResponse<?>> getUserRanking(Long userId);
+
+    @Operation(
+            summary = "오늘의 씨앗 적립 현황",
+            description = "사용자의 오늘 씨앗 적립 현황(출석, 응원, 파밍로그)을 조회하는 API입니다.  \n" +
+                    "오늘 씨앗 적립 현황은 0시 기준으로 갱신됩니다. ",
+            security = @SecurityRequirement(name = "token")
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "오늘의 씨앗 적립 현황 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = TodaySeedResponseDTO.class)
+                    )),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음")
+    })
+    @GetMapping("/{userId}/daily-seed")
+    ResponseEntity<SuccessResponse<?>> getTodaySeed(Long userId);
 }
 

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.user.dto.request.UserUpdateRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.request.UserVerifyRequestDTO;
 import org.farmsystem.homepage.domain.user.dto.response.*;
+import org.farmsystem.homepage.domain.user.service.DailySeedService;
 import org.farmsystem.homepage.domain.user.service.RankingService;
 import org.farmsystem.homepage.domain.user.service.UserService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController implements UserApi {
     private final UserService userService;
     private final RankingService rankingService;
+    private final DailySeedService dailySeedService;
 
     // 사용자 회원 인증 API
     @PostMapping("/verify")
@@ -73,5 +75,12 @@ public class UserController implements UserApi {
     public ResponseEntity<SuccessResponse<?>> getUserRanking(@AuthenticationPrincipal Long userId) {
         UserRankListResponseDTO userRankList = rankingService.getDailyRanking(userId);
         return SuccessResponse.ok(userRankList);
+    }
+
+    //오늘의 씨앗 적립 현황;
+    @GetMapping("/today-seed")
+    public ResponseEntity<SuccessResponse<?>> getSeed(@AuthenticationPrincipal Long userId) {
+        TodaySeedResponseDTO todaySeed = dailySeedService.getTodaySeed(userId);
+        return SuccessResponse.ok(todaySeed);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/UserController.java
@@ -77,9 +77,9 @@ public class UserController implements UserApi {
         return SuccessResponse.ok(userRankList);
     }
 
-    //오늘의 씨앗 적립 현황;
+    //오늘의 씨앗 적립 현황
     @GetMapping("/today-seed")
-    public ResponseEntity<SuccessResponse<?>> getSeed(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<SuccessResponse<?>> getTodaySeed(@AuthenticationPrincipal Long userId) {
         TodaySeedResponseDTO todaySeed = dailySeedService.getTodaySeed(userId);
         return SuccessResponse.ok(todaySeed);
     }

--- a/src/main/java/org/farmsystem/homepage/domain/user/dto/response/TodaySeedResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/dto/response/TodaySeedResponseDTO.java
@@ -1,0 +1,17 @@
+package org.farmsystem.homepage.domain.user.dto.response;
+
+import org.farmsystem.homepage.domain.user.entity.DailySeed;
+
+public record TodaySeedResponseDTO(
+        boolean isAttendance,
+        boolean isCheer,
+        boolean isFarminglog
+) {
+    public static TodaySeedResponseDTO from(DailySeed dailySeed) {
+        return new TodaySeedResponseDTO(
+                dailySeed.isAttendance(),
+                dailySeed.isCheer(),
+                dailySeed.isFarminglog()
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
@@ -2,6 +2,7 @@ package org.farmsystem.homepage.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.farmsystem.homepage.domain.user.dto.response.TodaySeedResponseDTO;
 import org.farmsystem.homepage.domain.user.entity.DailySeed;
 import org.farmsystem.homepage.domain.user.entity.SeedEventType;
 import org.farmsystem.homepage.domain.user.entity.User;
@@ -66,6 +67,16 @@ public class DailySeedService {
                 user.addTotalSeed(eventType.getSeedAmount());
                 break;
         }
+    }
+
+    public TodaySeedResponseDTO getTodaySeed(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));
+
+        DailySeed dailySeed = dailySeedRepository.findByUser(user)
+                .orElseGet(() -> new DailySeed(user));
+
+        return TodaySeedResponseDTO.from(dailySeed);
     }
 
     @Transactional

--- a/src/main/java/org/farmsystem/homepage/domain/user/service/TokenService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/TokenService.java
@@ -88,11 +88,8 @@ public class TokenService {
         jwtProvider.equalsRefreshToken(refreshToken, storedRefreshToken);
 
         String newAccessToken = issueNewAccessToken(userId);
-        String newRefreshToken = issueNewRefreshToken(userId);
 
-        redisTemplate.opsForValue().set(redisKey, newRefreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
-
-        return UserTokenResponseDTO.of(newAccessToken, newRefreshToken);
+        return UserTokenResponseDTO.of(newAccessToken, refreshToken);
     }
 
     public void logout(Long userId) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #131 
 
## 🌱 작업 사항
- 기존 엑세스 토큰 재발급시 리프레쉬 토큰도 재발급 되는 문제 해결
=> 리프레쉬 재발급 코드 삭제 후 레디스에 저장된 기존 토큰을 반환합니다.

- 오늘의 씨앗 적립 조회 API 구현 (출석, 응원, 파밍로그)

