### PR TITLE
[fix] #135 유저 새로 생성될 때 기존 랭킹 캐시 삭제

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/UserService.java
@@ -15,6 +15,7 @@ import org.farmsystem.homepage.domain.user.repository.UserRepository;
 import org.farmsystem.homepage.global.error.exception.BusinessException;
 import org.farmsystem.homepage.global.error.exception.EntityNotFoundException;
 import org.farmsystem.homepage.global.error.exception.UnauthorizedException;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,7 +34,7 @@ public class UserService {
     private final PassedApplyRepository passedApplyRepository;
     private final TrackHistoryRepository trackHistoryRepository;
     private final DailySeedService dailySeedService;
-    private final DailySeedRepository dailySeedRepository;
+    private final CacheManager cacheManager;
 
     public UserVerifyResponseDTO verifyUser(UserVerifyRequestDTO userVerifyRequest) {
         PassedApply verifiedUser = passedApplyRepository.findByStudentNumber(userVerifyRequest.studentNumber())
@@ -73,6 +74,8 @@ public class UserService {
             // 소셜로그인 다른 계정으로 이미 가입한 경우 예외 처리
             checkIfUserAlreadyRegistered(studentNumber);
 
+            // 랭킹 캐시 삭제
+            cacheManager.getCache("dailySeedRanking").evict("all");
             return createUserFromPassedUser(studentNumber, userLoginRequest, socialId, imageUrl);
         }
         return existedUser;


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #135 
 
## 🌱 작업 사항
### 현재 문제 상황 
유저 새로 생성했을 때 내 랭킹 null 오류 원인은 
- `userRankList` 랭킹 리스트 데이터는 0시에 업데이트되는 캐싱 데이터  
- `myRank` 는 위 userRankList 데이터에서 내 랭크를 찾는 방식

인데 캐싱된 랭킹리스트에 새로 만든 유저정보가 없으니까(이거는 원래 12시에 업데이트 반영) null로 들어감!

### 현재의 고민
- 멤버가 새로 생길 때 랭킹 임의로 업데이트 해버리면 캐싱된 데이터를 사용하고 있는 다른 유저와 랭크데이터 싱크가 안 맞는 문제 발생
- 변경시 매번 캐싱 데이터 업데이트 하더라도 업데이트의 범위를 정해야함! (유저가 생성될때 or 씨앗이 적립될 때 or 프로필 이미지 등 랭크에 보여지는 정보  등 중 하나라도 변경이 생겼을 때)
- 대안으로는 유저 생성시 해당 유저는 랭킹에 추가하고(이 시간 동안은 안 맞을 수 있음) 다른 유저를 포함한 랭킹 업데이트 주기는 좀 더 짧게 가져가기 등의 방법이 있을 거 같음

### 현재 해결 방법 
일단 위 방안에 대해서 논의가 좀 더 필요할 거 같아서 현재는 단순하게 유저가 생성될 때 캐싱 데이터 삭제 하는 방식을 사용함 
=> 유저 생성 될 때 마다 캐싱 데이터 안쓰고 쿼리 조회문으로 가져옴


