### PR TITLE
[bug] 알림 title 길이 제한, 파밍로그 알림 전송 조건

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/entity/FarmingLogLike.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/entity/FarmingLogLike.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.farmsystem.homepage.domain.common.entity.BaseTimeEntity;
 import org.farmsystem.homepage.domain.user.entity.User;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
@@ -25,4 +26,11 @@ public class FarmingLogLike extends BaseTimeEntity {
     @JoinColumn(name = "farming_log_id", nullable = false)
     private FarmingLog farmingLog;
 
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    private boolean isDeleted;
+
+    public void updateDelete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/repository/FarmingLogLikeRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/repository/FarmingLogLikeRepository.java
@@ -11,7 +11,8 @@ import java.util.Optional;
 @Repository
 public interface FarmingLogLikeRepository extends JpaRepository<FarmingLogLike, Long> {
 
-    Optional<FarmingLogLike> findByUserAndFarmingLog(User user, FarmingLog farmingLog);
-    long countByFarmingLog(FarmingLog farmingLog);
+    Optional<FarmingLogLike> findByUserAndFarmingLogAndIsDeletedFalse(User user, FarmingLog farmingLog);
+    long countByFarmingLogAndIsDeletedFalse(FarmingLog farmingLog);
     boolean existsByUserAndFarmingLog(User user, FarmingLog farmingLog);
+    boolean existsByUserAndFarmingLogAndIsDeletedFalse(User user, FarmingLog farmingLog);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogLikeService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogLikeService.java
@@ -31,12 +31,10 @@ public class FarmingLogLikeService {
 
         FarmingLog farmingLog = farmingLogRepository.findById(farmingLogId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FARMING_LOG_NOT_FOUND));
-
-        boolean isLikeAdded;
-        Optional<FarmingLogLike> existingLike = farmingLogLikeRepository.findByUserAndFarmingLog(user, farmingLog);
+        Optional<FarmingLogLike> existingLike = farmingLogLikeRepository.findByUserAndFarmingLogAndIsDeletedFalse(user, farmingLog);
         if (existingLike.isPresent()) {
-            farmingLogLikeRepository.delete(existingLike.get());
             isLikeAdded = false;
+            existingLike.get().updateDelete();
         } else {
             farmingLogLikeRepository.save(
                     FarmingLogLike.builder()

--- a/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/farmingLog/service/FarmingLogService.java
@@ -27,8 +27,8 @@ public class FarmingLogService {
     private final DailySeedService dailySeedService;
 
     private FarmingLogResponseDTO mapToFarmingLogResponse(FarmingLog farmingLog, User currentUser) {
-        boolean isLiked = farmingLogLikeRepository.existsByUserAndFarmingLog(currentUser, farmingLog);
-        long likeCount = farmingLogLikeRepository.countByFarmingLog(farmingLog);
+        boolean isLiked = farmingLogLikeRepository.existsByUserAndFarmingLogAndIsDeletedFalse(currentUser, farmingLog);
+        long likeCount = farmingLogLikeRepository.countByFarmingLogAndIsDeletedFalse(farmingLog);
 
         return FarmingLogResponseDTO.from(farmingLog, currentUser.getUserId(), isLiked, likeCount);
     }

--- a/src/main/java/org/farmsystem/homepage/domain/notification/entity/Notification.java
+++ b/src/main/java/org/farmsystem/homepage/domain/notification/entity/Notification.java
@@ -25,7 +25,7 @@ public class Notification extends BaseTimeEntity {
     @Column(nullable = false, length = 20)
     private NotificationType type;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 20)
     private String title;
 
     @Column(nullable = false, length = 50)


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #138 
 
## 🌱 작업 사항
- Notification 엔티티 title length 20으로 조정
- 파밍로그 좋아요 기록에 soft delete 적용
- 첫 좋아요인 경우, 자기 자신의 파밍로그가 아닌 경우에만 알림 전송

## 🌱 참고 사항
- 좋아요 취소 시 파밍로그 좋아요 매핑 테이블에 is_deleted true로 표시하고, 어떤 기록도 없을 경우에만 알림 전송하도록 함
