### PR TITLE
[refactor/feat] 뉴스 반환값 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/request/NewsRequestDTO.java
@@ -1,5 +1,20 @@
 package org.farmsystem.homepage.domain.news.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
-public record NewsRequestDTO(String title, String content, String thumbnailUrl, List<String> imageUrls) { }
+@Schema(description = "소식 작성 요청 DTO")
+public record NewsRequestDTO(
+        @Schema(description = "소식 제목", example = "파밍 시스템 리뉴얼 안내")
+        String title,
+
+        @Schema(description = "소식 본문", example = "파밍 시스템이 새롭게 리뉴얼되었습니다. 자세한 사항은 홈페이지를 참고하세요.")
+        String content,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://s3-bucket/thumbnail.jpg")
+        String thumbnailUrl,
+
+        @Schema(description = "본문에 첨부될 이미지 URL 목록", example = "[\"https://s3-bucket/image1.jpg\", \"https://s3-bucket/image2.jpg\"]")
+        List<String> imageUrls
+) {}

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
@@ -1,10 +1,27 @@
 package org.farmsystem.homepage.domain.news.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.farmsystem.homepage.domain.news.entity.News;
 
 import java.util.List;
 
-public record NewsDetailResponseDTO(Long newsId, String title, String thumbnailUrl, String content, List<String> imageUrls) {
+@Schema(description = "소식 상세 응답 DTO")
+public record NewsDetailResponseDTO(
+        @Schema(description = "소식 ID", example = "1")
+        Long newsId,
+
+        @Schema(description = "소식 제목", example = "5월 활동 요약")
+        String title,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://s3-bucket/thumbnail.jpg")
+        String thumbnailUrl,
+
+        @Schema(description = "소식 본문", example = "파밍 시스템 5월 활동 보고입니다.")
+        String content,
+
+        @Schema(description = "본문 이미지 URL 목록", example = "[\"https://s3/image1.jpg\", \"https://s3/image2.jpg\"]")
+        List<String> imageUrls
+) {
     public static NewsDetailResponseDTO fromEntity(News news) {
         return new NewsDetailResponseDTO(
                 news.getNewsId(),

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
@@ -3,6 +3,7 @@ package org.farmsystem.homepage.domain.news.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.farmsystem.homepage.domain.news.entity.News;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "소식 상세 응답 DTO")
@@ -20,7 +21,13 @@ public record NewsDetailResponseDTO(
         String content,
 
         @Schema(description = "본문 이미지 URL 목록", example = "[\"https://s3/image1.jpg\", \"https://s3/image2.jpg\"]")
-        List<String> imageUrls
+        List<String> imageUrls,
+
+        @Schema(description = "작성일", example = "2025-05-18T15:30:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일", example = "2025-05-18T15:45:00")
+        LocalDateTime updatedAt
 ) {
     public static NewsDetailResponseDTO fromEntity(News news) {
         return new NewsDetailResponseDTO(
@@ -28,7 +35,9 @@ public record NewsDetailResponseDTO(
                 news.getTitle(),
                 news.getThumbnailUrl(),
                 news.getContent(),
-                news.getImageUrls()
+                news.getImageUrls(),
+                news.getCreatedAt(),
+                news.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsDetailResponseDTO.java
@@ -1,5 +1,17 @@
 package org.farmsystem.homepage.domain.news.dto.response;
 
+import org.farmsystem.homepage.domain.news.entity.News;
+
 import java.util.List;
 
-public record NewsDetailResponseDTO(Long newsId, String title, String thumbnailUrl, String content, List<String> imageUrls) { }
+public record NewsDetailResponseDTO(Long newsId, String title, String thumbnailUrl, String content, List<String> imageUrls) {
+    public static NewsDetailResponseDTO fromEntity(News news) {
+        return new NewsDetailResponseDTO(
+                news.getNewsId(),
+                news.getTitle(),
+                news.getThumbnailUrl(),
+                news.getContent(),
+                news.getImageUrls()
+        );
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
@@ -1,3 +1,9 @@
 package org.farmsystem.homepage.domain.news.dto.response;
 
-public record NewsListResponseDTO(Long newsId, String title, String thumbnailUrl) { }
+import org.farmsystem.homepage.domain.news.entity.News;
+
+public record NewsListResponseDTO(Long newsId, String title, String thumbnailUrl) {
+    public static NewsListResponseDTO fromEntity(News news) {
+        return new NewsListResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl());
+    }
+}

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
@@ -1,8 +1,19 @@
 package org.farmsystem.homepage.domain.news.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.farmsystem.homepage.domain.news.entity.News;
 
-public record NewsListResponseDTO(Long newsId, String title, String thumbnailUrl) {
+@Schema(description = "소식 목록 응답 DTO")
+public record NewsListResponseDTO(
+        @Schema(description = "소식 ID", example = "1")
+        Long newsId,
+
+        @Schema(description = "소식 제목", example = "5월 활동 요약")
+        String title,
+
+        @Schema(description = "썸네일 이미지 URL", example = "https://s3-bucket/thumbnail.jpg")
+        String thumbnailUrl
+) {
     public static NewsListResponseDTO fromEntity(News news) {
         return new NewsListResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl());
     }

--- a/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/dto/response/NewsListResponseDTO.java
@@ -3,6 +3,8 @@ package org.farmsystem.homepage.domain.news.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.farmsystem.homepage.domain.news.entity.News;
 
+import java.time.LocalDateTime;
+
 @Schema(description = "소식 목록 응답 DTO")
 public record NewsListResponseDTO(
         @Schema(description = "소식 ID", example = "1")
@@ -12,9 +14,30 @@ public record NewsListResponseDTO(
         String title,
 
         @Schema(description = "썸네일 이미지 URL", example = "https://s3-bucket/thumbnail.jpg")
-        String thumbnailUrl
+        String thumbnailUrl,
+
+        @Schema(description = "본문 미리보기", example = "이번 달 파밍시스템 활동은... (최대 50자)")
+        String contentPreview,
+
+        @Schema(description = "작성일", example = "2025-05-18T12:34:56")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일", example = "2025-05-18T12:35:56")
+        LocalDateTime updatedAt
 ) {
     public static NewsListResponseDTO fromEntity(News news) {
-        return new NewsListResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl());
+        return new NewsListResponseDTO(
+                news.getNewsId(),
+                news.getTitle(),
+                news.getThumbnailUrl(),
+                extractPreview(news.getContent()),
+                news.getCreatedAt(),
+                news.getUpdatedAt()
+        );
+    }
+
+    private static String extractPreview(String content) {
+        if (content == null) return "";
+        return content.length() <= 50 ? content : content.substring(0, 50) + "...";
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/news/service/NewsService.java
@@ -22,26 +22,26 @@ public class NewsService {
 
     public List<NewsListResponseDTO> getAllNews() {
         return newsRepository.findAll().stream()
-                .map(news -> new NewsListResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl()))
+                .map(NewsListResponseDTO::fromEntity)
                 .collect(Collectors.toList());
     }
 
     public NewsDetailResponseDTO getNewsById(Long newsId) {
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEWS_NOT_FOUND));
-        return new NewsDetailResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl(), news.getContent(), news.getImageUrls());
+        return NewsDetailResponseDTO.fromEntity(news);
     }
 
     @Transactional
     public NewsDetailResponseDTO createNews(NewsRequestDTO request) {
-        News news = News.builder()
-                .title(request.title())
-                .content(request.content())
-                .thumbnailUrl(request.thumbnailUrl())
-                .imageUrls(request.imageUrls())
-                .build();
+        News news = new News(
+                request.title(),
+                request.content(),
+                request.thumbnailUrl(),
+                request.imageUrls()
+        );
         newsRepository.save(news);
-        return new NewsDetailResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl(), news.getContent(), news.getImageUrls());
+        return NewsDetailResponseDTO.fromEntity(news);
     }
 
     @Transactional
@@ -49,7 +49,7 @@ public class NewsService {
         News news = newsRepository.findById(newsId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEWS_NOT_FOUND));
         news.updateNews(request.title(), request.content(), request.thumbnailUrl(), request.imageUrls());
-        return new NewsDetailResponseDTO(news.getNewsId(), news.getTitle(), news.getThumbnailUrl(), news.getContent(), news.getImageUrls());
+        return NewsDetailResponseDTO.fromEntity(news);
     }
 
     @Transactional


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #89 
 
## 🌱 작업 사항
- 뉴스에 이미지 추가
- 문서 작성
- 뉴스 리스트에 내용 50자 반환 추가
- 모든 뉴스 response에 createdAt, updatedAt 추가

