### PR TITLE
[fix] JVM 힙 메모리 제한 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,6 @@ ARG JAR_FILE=build/libs/HomePage-BE-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 
 # JVM 시간대 설정을 포함한 애플리케이션 실행
-ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]
+# -Xmx256m	최대 힙 메모리를 256MB로 제한
+# -Xms128m	초기 힙 메모리 크기를 128MB로 설정
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-Xmx256m", "-Xms128m", "-jar", "/app.jar"]


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #151
 
## 🌱 작업 사항

![i-03064785268776133](https://github.com/user-attachments/assets/fe74106c-3b3f-4d09-9a5a-f5beae33004a)
<img width="572" alt="스크린샷 2025-05-18 오후 10 50 06" src="https://github.com/user-attachments/assets/a1b6d619-30d4-49c6-adb6-4a2bc53d783c" />

-Xmx256m | 최대 힙 메모리를 256MB로 제한
-Xms128m | 초기 힙 메모리 크기를 128MB로 설정

</div></div>


## 🌱 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
