### PR TITLE
[fix] @Lock으로 인해 발생한 READ ONLY 트랜잭션 오류 해결

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/service/DailySeedService.java
@@ -78,6 +78,7 @@ public class DailySeedService {
         }
     }
 
+    @Transactional
     public TodaySeedResponseDTO getTodaySeed(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(USER_NOT_FOUND));


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #148
 
## 🌱 작업 사항
getTodaySeed 메서드는 조회 용도로 사용되는 트랜잭션이지만 중복요청 방지용을 @Lock을 걸어두면서 PESSIMISTIC_WRITE (FOR UPDATE)를 포함하는 쿼리를 실행함 -> Transactional ReadOnly 에러가 발생 -> @Transactional 덮어써서 해결


