### PR TITLE
[docs] 운영환경 임시토큰 발급 API Swagger 문서에서 제거

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/user/controller/AuthApi.java
+++ b/src/main/java/org/farmsystem/homepage/domain/user/controller/AuthApi.java
@@ -31,7 +31,6 @@ public interface AuthApi {
                     )),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @Profile("!prod") // 운영 환경에서는 사용하지 않도록 설정
     ResponseEntity<SuccessResponse<?>> getTempToken(
             @Parameter(description = "토큰을 발급 받을 사용자의 ID") @PathVariable Long userId
     );

--- a/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
+++ b/src/main/java/org/farmsystem/homepage/global/config/SwaggerConfig.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 
 import static io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER;
 
@@ -40,5 +42,12 @@ public class SwaggerConfig {
                 .info(info)
                 .components(components)
                 .addServersItem(server);
+    }
+
+    //운영환경 임시토큰 발급 API Swagger 문서에서 제거
+    @Bean
+    @Profile("prod")
+    public GlobalOpenApiCustomizer hidePaths() {
+        return openApi -> openApi.getPaths().remove("/api/auth/token/{userId}");
     }
 }


### PR DESCRIPTION
## 🌱 작업 사항
- 이전에 작성한 @Profile은 swagger명세 작성한 인터페이스에서 동작을 안함 
- @Hidden으로도 특정 API를 숨길 수 있으나 특정 환경에서의 적용은 안됨 (스웨거는 동적 생성인데  @Hidden은 정적 어노테이션이어서인듯)
 
=> 특정 API 명세를 특정 환경에서 숨기기 위한 조건부 Bean 등록 추가