### PR TITLE
Feat/#175 minigame

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/BadgeController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/BadgeController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.player.dto.request.BadgeUpdateRequestDTO;
 import org.farmsystem.homepage.domain.minigame.player.dto.response.BadgeResponseDTO;
 import org.farmsystem.homepage.domain.minigame.player.service.BadgeService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,16 +20,18 @@ public class BadgeController {
 
     // 전체 칭호 조회
     @GetMapping
-    public List<BadgeResponseDTO> getBadges(@AuthenticationPrincipal Long userId) {
-        return badgeService.getBadges(userId);
+    public ResponseEntity<SuccessResponse<?>> getBadges(@AuthenticationPrincipal Long userId) {
+        List<BadgeResponseDTO> response = badgeService.getBadges(userId);
+        return SuccessResponse.ok(response);
     }
 
     // 칭호 추가
     @PostMapping
-    public BadgeResponseDTO addBadge(
+    public ResponseEntity<SuccessResponse<?>> addBadge(
             @AuthenticationPrincipal Long userId,
             @RequestBody BadgeUpdateRequestDTO request
     ) {
-        return badgeService.addBadge(userId, request);
+        BadgeResponseDTO response = badgeService.addBadge(userId, request);
+        return SuccessResponse.created(response);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/DailyGameController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/DailyGameController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.player.dto.request.GameTypeRequestDTO;
 import org.farmsystem.homepage.domain.minigame.player.dto.response.GameCountResponseDTO;
 import org.farmsystem.homepage.domain.minigame.player.service.DailyGameService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,19 +18,21 @@ public class DailyGameController {
 
     // 게임 횟수 조회
     @GetMapping("/{gameType}")
-    public GameCountResponseDTO getGameCount(
+    public ResponseEntity<SuccessResponse<?>> getGameCount(
             @AuthenticationPrincipal Long userId,
             @PathVariable String gameType
     ) {
-        return dailyGameService.getGameCount(userId, gameType);
+        GameCountResponseDTO response = dailyGameService.getGameCount(userId, gameType);
+        return SuccessResponse.ok(response);
     }
 
-    // 게임 횟수 증가
-    @PatchMapping("/increment")
-    public GameCountResponseDTO incrementGameCount(
+    // 게임 횟수 1회 소모
+    @PatchMapping("/use")
+    public ResponseEntity<SuccessResponse<?>> useGame(
             @AuthenticationPrincipal Long userId,
             @RequestBody GameTypeRequestDTO request
     ) {
-        return dailyGameService.incrementGameCount(userId, request);
+        GameCountResponseDTO response = dailyGameService.useGame(userId, request);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/BadgeUpdateRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/BadgeUpdateRequestDTO.java
@@ -1,6 +1,8 @@
 package org.farmsystem.homepage.domain.minigame.player.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+
 public record BadgeUpdateRequestDTO(
-        Integer badgeType
+        @NotNull Integer badgeType
 ) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/GameTypeRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/GameTypeRequestDTO.java
@@ -1,6 +1,8 @@
 package org.farmsystem.homepage.domain.minigame.player.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record GameTypeRequestDTO(
-        String gameType
+        @NotBlank String gameType
 ) {
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/response/GameCountResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/response/GameCountResponseDTO.java
@@ -7,6 +7,6 @@ public record GameCountResponseDTO(
         int count
 ) {
     public static GameCountResponseDTO from(DailyGame dailyGame, String gameType) {
-        return new GameCountResponseDTO(gameType, dailyGame.getGameCount(gameType));
+        return new GameCountResponseDTO(gameType, dailyGame.getRemainingCount(gameType));
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/Badge.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/Badge.java
@@ -8,7 +8,6 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class Badge {  //칭호
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,10 +21,13 @@ public class Badge {  //칭호
     @JoinColumn(name = "player_id")
     private Player player;
 
-    public static Badge create(Player player, Integer badgeType) {
-        return Badge.builder()
-                .badgeType(badgeType)
-                .player(player)
-                .build();
+    // 플레이어가 새로운 칭호를 획득할 때 사용하는 생성 메서드
+    public static Badge createBadge(Player player, Integer badgeType) {
+        return new Badge(player, badgeType);
+    }
+    // 생성은 createBadge만 사용
+    private Badge(Player player, Integer badgeType) {
+        this.player = player;
+        this.badgeType = badgeType;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/DailyGame.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/DailyGame.java
@@ -19,13 +19,13 @@ public class DailyGame {
     private Long gameId;
 
     @Column(name = "rock_scissors_game", nullable = false)
-    private Integer rockScissors;
+    private Integer rockScissors; // 남은 횟수
 
     @Column(name = "carrot_game", nullable = false)
-    private Integer carrotGame;
+    private Integer carrotGame; // 남은 횟수
 
     @Column(name = "sunlight_game", nullable = false)
-    private Integer sunlightGame;
+    private Integer sunlightGame; // 남은 횟수
 
     @Column(name = "last_reset_date", nullable = false)
     private LocalDate lastResetDate;
@@ -34,44 +34,56 @@ public class DailyGame {
     @JoinColumn(name = "player_id", nullable = false)
     private Player player;
 
-    public static DailyGame createNew(Player player) {
-        return DailyGame.builder()
-                .player(player)
-                .rockScissors(0)
-                .carrotGame(0)
-                .sunlightGame(0)
-                .lastResetDate(LocalDate.now())
-                .build();
+    public static DailyGame createDailyGame(Player player) {
+        return new DailyGame(player, 3, 3, 3, LocalDate.now());
     }
 
+    // 날짜가 바뀌었으면 횟수를 초기화한다 (다시 3회로 초기화)
     public void resetIfNeeded() {
         if (!LocalDate.now().equals(this.lastResetDate)) {
             resetCounts();
         }
     }
-
     public void resetCounts() {
-        this.rockScissors = 0;
-        this.carrotGame = 0;
-        this.sunlightGame = 0;
+        this.rockScissors = 3;
+        this.carrotGame = 3;
+        this.sunlightGame = 3;
         this.lastResetDate = LocalDate.now();
     }
 
-    public void incrementGame(String gameType) {
+    // 게임 횟수를 1회 차감(0보다 작아질 수 없음)
+    public void useGame(String gameType) {
         switch (gameType.toLowerCase()) {
-            case "rock" -> this.rockScissors++;
-            case "carrot" -> this.carrotGame++;
-            case "sunlight" -> this.sunlightGame++;
+            case "rock" -> {
+                if (rockScissors <= 0) throw new IllegalStateException("rock game 횟수 모두 소진됨");
+                this.rockScissors--;
+            }
+            case "carrot" -> {
+                if (carrotGame <= 0) throw new IllegalStateException("carrot game 횟수 모두 소진됨");
+                this.carrotGame--;
+            }
+            case "sunlight" -> {
+                if (sunlightGame <= 0) throw new IllegalStateException("sunlight game 횟수 모두 소진됨");
+                this.sunlightGame--;
+            }
             default -> throw new IllegalArgumentException("Invalid game type: " + gameType);
         }
     }
-
-    public int getGameCount(String gameType) {
+    // 현재 게임의 남은 횟수 반환
+    public int getRemainingCount(String gameType) {
         return switch (gameType.toLowerCase()) {
             case "rock" -> this.rockScissors;
             case "carrot" -> this.carrotGame;
             case "sunlight" -> this.sunlightGame;
             default -> throw new IllegalArgumentException("Invalid game type: " + gameType);
         };
+    }
+
+    private DailyGame(Player player, int rock, int carrot, int sunlight, LocalDate resetDate) {
+        this.player = player;
+        this.rockScissors = rock;
+        this.carrotGame = carrot;
+        this.sunlightGame = sunlight;
+        this.lastResetDate = resetDate;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/BadgeService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/BadgeService.java
@@ -21,11 +21,12 @@ public class BadgeService {
     private final BadgeRepository badgeRepository;
     private final PlayerRepository playerRepository;
 
+    // 플레이어 조회
     private Player findPlayerOrThrow(Long userId) {
         return playerRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAYER_NOT_FOUND));
     }
-
+    // 플레이어의 전체 칭호 조회
     @Transactional(readOnly = true)
     public List<BadgeResponseDTO> getBadges(Long userId) {
         Player player = findPlayerOrThrow(userId);
@@ -35,7 +36,7 @@ public class BadgeService {
                 .map(BadgeResponseDTO::from)
                 .toList();
     }
-
+    // 새로운 칭호 등록
     @Transactional
     public BadgeResponseDTO addBadge(Long userId, BadgeUpdateRequestDTO request) {
         Player player = findPlayerOrThrow(userId);
@@ -44,7 +45,7 @@ public class BadgeService {
             throw new BusinessException(ErrorCode.BADGE_ALREADY_EXISTS);
         }
 
-        Badge badge = badgeRepository.save(Badge.create(player, request.badgeType()));
+        Badge badge = badgeRepository.save(Badge.createBadge(player, request.badgeType()));
         return BadgeResponseDTO.from(badge);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/controller/SolarController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/controller/SolarController.java
@@ -3,6 +3,8 @@ package org.farmsystem.homepage.domain.minigame.solarstation.controller;
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.solarstation.dto.SolarDTO;
 import org.farmsystem.homepage.domain.minigame.solarstation.service.SolarService;
+import org.farmsystem.homepage.global.common.SuccessResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,17 +14,20 @@ import org.springframework.web.bind.annotation.*;
 public class SolarController {
 
     private final SolarService solarService;
-
+    // 플레이어의 태양광 발전소 상태 조회
     @GetMapping
-    public SolarDTO getSolarStation(@AuthenticationPrincipal Long userId) {
-        return solarService.getSolarStation(userId);
+    public ResponseEntity<SuccessResponse<?>> getSolarStation(@AuthenticationPrincipal Long userId) {
+        SolarDTO response = solarService.getSolarStation(userId);
+        return SuccessResponse.ok(response);
     }
 
+    // 플레이어의 태양광 발전소 상태 업데이트
     @PatchMapping("/chargetime")
-    public SolarDTO updateChargeTime(
+    public ResponseEntity<SuccessResponse<?>> updateChargeTime(
             @AuthenticationPrincipal Long userId,
             @RequestBody SolarDTO request
     ) {
-        return solarService.updateChargeTime(userId, request);
+        SolarDTO response = solarService.updateChargeTime(userId, request);
+        return SuccessResponse.ok(response);
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/dto/SolarDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/dto/SolarDTO.java
@@ -1,12 +1,14 @@
 package org.farmsystem.homepage.domain.minigame.solarstation.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import org.farmsystem.homepage.domain.minigame.solarstation.entity.SolarPowerStation;
 
 import java.time.LocalDateTime;
 
 public record SolarDTO(
         LocalDateTime chargeStartTime,
-        Integer level
+        @Min(0) @Max(100) Integer level
 ) {
     public static SolarDTO from(SolarPowerStation station) {
         return new SolarDTO(

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/entity/SolarPowerStation.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/entity/SolarPowerStation.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
 public class SolarPowerStation {
 
     @Id
@@ -29,21 +28,26 @@ public class SolarPowerStation {
     @JoinColumn(name = "player_id", nullable = false, unique = true)
     private Player player;
 
-    public static SolarPowerStation createNew(Player player) {
-        return SolarPowerStation.builder()
-                .player(player)
-                .level(0)
-                .chargeStartedAt(null)
-                .build();
+    // 플레이어의 태양광 발전소를 처음 생성
+    public static SolarPowerStation createSolarStation(Player player) {
+        return new SolarPowerStation(player, 0, null);
     }
 
-    public void startChargeAt(LocalDateTime startedAt) {
-        this.chargeStartedAt = startedAt;
+    // 발전소 상태 업데이트
+    public void updateState(LocalDateTime startedAt, Integer newLevel) {
+        if (startedAt != null) {
+            this.chargeStartedAt = startedAt;
+        }
+        if (newLevel != null) {
+            int clamped = Math.max(0, Math.min(100, newLevel));
+            this.level = clamped;
+        }
     }
 
-    // 0~100 범위
-    public void changeLevel(int newLevel) {
-        int clamped = Math.max(0, Math.min(100, newLevel));
-        this.level = clamped;
+    // createSolarStation으로만 생성
+    private SolarPowerStation(Player player, int level, LocalDateTime chargeStartedAt) {
+        this.player = player;
+        this.level = level;
+        this.chargeStartedAt = chargeStartedAt;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/repository/SolarRepository.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/repository/SolarRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+// 플레이어별 발전소 조회
 public interface SolarRepository extends JpaRepository<SolarPowerStation, Long> {
     Optional<SolarPowerStation> findByPlayer(Player player);
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/service/SolarService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/service/SolarService.java
@@ -1,6 +1,6 @@
 package org.farmsystem.homepage.domain.minigame.solarstation.service;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.player.entity.Player;
 import org.farmsystem.homepage.domain.minigame.player.repository.PlayerRepository;
@@ -10,6 +10,7 @@ import org.farmsystem.homepage.domain.minigame.solarstation.repository.SolarRepo
 import org.farmsystem.homepage.global.error.exception.BusinessException;
 import org.farmsystem.homepage.global.error.ErrorCode;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,35 +18,30 @@ public class SolarService {
 
     private final SolarRepository solarRepository;
     private final PlayerRepository playerRepository;
-
+    // 플레이어 조회
     private Player findPlayerOrThrow(Long userId) {
         return playerRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
-
+    // 플레이어에게 발전소가 없으면 생성
     private SolarPowerStation getOrCreateStation(Player player) {
         return solarRepository.findByPlayer(player)
-                .orElseGet(() -> solarRepository.save(SolarPowerStation.createNew(player)));
+                .orElseGet(() -> solarRepository.save(SolarPowerStation.createSolarStation(player)));
     }
-
-    @Transactional
+    // 플레이어의 태양광 발전소 조회
+    @Transactional(readOnly=true)
     public SolarDTO getSolarStation(Long userId) {
         Player player = findPlayerOrThrow(userId);
         SolarPowerStation station = getOrCreateStation(player);
         return SolarDTO.from(station);
     }
-
+    // 발전소 상태(충전 시간, 레벨) 업데이트
     @Transactional
     public SolarDTO updateChargeTime(Long userId, SolarDTO request) {
         Player player = findPlayerOrThrow(userId);
         SolarPowerStation station = getOrCreateStation(player);
 
-        if (request.chargeStartTime() != null) {
-            station.startChargeAt(request.chargeStartTime());
-        }
-        if (request.level() != null) {
-            station.changeLevel(request.level());
-        }
+        station.updateState(request.chargeStartTime(), request.level());
 
         return SolarDTO.from(station);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #171 
 
## 🌱 작업 사항

공통 수정사항
- Builder 제거 & 엔티티 비즈니스 메서드 사용
- SuccessResponse로 응답 통일
- DTO에 validation 적용

Dailygame
- 게임 횟수 관리 로직을 남은 횟수(3→0) 기준으로 변경

## 🌱 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
