### PR TITLE
[fix] #172 Player 관련 api 수정, 추가

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/PlayerController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/controller/PlayerController.java
@@ -2,6 +2,7 @@ package org.farmsystem.homepage.domain.minigame.player.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.player.dto.PlayerCurrencyDTO;
+import org.farmsystem.homepage.domain.minigame.player.dto.request.LevelUpdateRequestDTO;
 import org.farmsystem.homepage.domain.minigame.player.dto.response.PlayerResponseDTO;
 import org.farmsystem.homepage.domain.minigame.player.service.PlayerService;
 import org.farmsystem.homepage.global.common.SuccessResponse;
@@ -21,17 +22,26 @@ public class PlayerController {
     public ResponseEntity<SuccessResponse<?>> getPlayerCurrency(
             @AuthenticationPrincipal Long userId
     ) {
-        PlayerCurrencyDTO response = playerService.getPlayerCurrency(userId);
+        PlayerResponseDTO response = playerService.getPlayerCurrency(userId);
         return SuccessResponse.ok(response);
     }
 
     //재화 업데이트
-    @PutMapping("/update")
+    @PatchMapping("/currency")
     public ResponseEntity<SuccessResponse<?>> updatePlayerCurrency(
             @AuthenticationPrincipal Long userId,
             @RequestBody PlayerCurrencyDTO requestDTO
     ){
-        PlayerCurrencyDTO response = playerService.updatePlayer(userId, requestDTO);
+        PlayerCurrencyDTO response = playerService.updateCurrency(userId, requestDTO);
+        return SuccessResponse.ok(response);
+    }
+
+    @PatchMapping("/level")
+    public ResponseEntity<SuccessResponse<?>> updatePlayerLevel(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody LevelUpdateRequestDTO requestDTO
+    ){
+        PlayerResponseDTO response = playerService.updateLevel(userId, requestDTO);
         return SuccessResponse.ok(response);
     }
 

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/PlayerCurrencyDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/PlayerCurrencyDTO.java
@@ -1,17 +1,20 @@
 package org.farmsystem.homepage.domain.minigame.player.dto;
 
+import jakarta.validation.constraints.NotNull;
 import org.farmsystem.homepage.domain.minigame.player.entity.Player;
 
 public record PlayerCurrencyDTO(
-        int seedticket,
-        int gold,
-        int sunlight
+        @NotNull Integer seedTicket,
+        @NotNull Integer gold,
+        @NotNull Integer sunlight,
+        @NotNull Integer seedCount
 ) {
     public static PlayerCurrencyDTO from(Player player) {
         return new PlayerCurrencyDTO(
                 player.getSeedTicket(),
                 player.getGold(),
-                player.getSunlight()
+                player.getSunlight(),
+                player.getSeedCount()
         );
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/LevelUpdateRequestDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/request/LevelUpdateRequestDTO.java
@@ -1,0 +1,6 @@
+package org.farmsystem.homepage.domain.minigame.player.dto.request;
+
+public record LevelUpdateRequestDTO (
+        int newLevel
+){
+}

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/response/PlayerResponseDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/dto/response/PlayerResponseDTO.java
@@ -3,20 +3,18 @@ package org.farmsystem.homepage.domain.minigame.player.dto.response;
 import org.farmsystem.homepage.domain.minigame.player.entity.Player;
 
 public record PlayerResponseDTO(
-        Long playerId,
-        Long userId,
         int seedTicket,
         int gold,
         int sunlight,
+        int seedCount,
         int level
 ) {
     public static PlayerResponseDTO from(Player p) {
         return new PlayerResponseDTO(
-                p.getPlayerId(),
-                p.getUser().getUserId(),
                 p.getSeedTicket(),
                 p.getGold(),
                 p.getSunlight(),
+                p.getSeedCount(),
                 p.getLevel()
         );
     }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/Player.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/entity/Player.java
@@ -27,6 +27,9 @@ public class Player extends BaseTimeEntity {
     private int sunlight = 0;
 
     @Column(nullable = false)
+    private int seedCount = 0;
+
+    @Column(nullable = false)
     private int level = 1;
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
@@ -39,14 +42,20 @@ public class Player extends BaseTimeEntity {
                 .seedTicket(0)
                 .gold(0)
                 .sunlight(0)
+                .seedCount(0)
                 .level(1)
                 .build();
     }
 
-    public void update(int seedTicket, int gold, int sunlight) {
+    public void updateCurrency(int seedTicket, int gold, int sunlight, int seedCount) {
         this.seedTicket = seedTicket;
         this.gold = gold;
         this.sunlight = sunlight;
+        this.seedCount = seedCount;
+    }
+
+    public void updateLevel(int level) {
+        this.level = level;
     }
 
     public void addTotalSeedTicket(int seedAmount) {

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/PlayerService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/PlayerService.java
@@ -2,6 +2,7 @@ package org.farmsystem.homepage.domain.minigame.player.service;
 
 import lombok.RequiredArgsConstructor;
 import org.farmsystem.homepage.domain.minigame.player.dto.PlayerCurrencyDTO;
+import org.farmsystem.homepage.domain.minigame.player.dto.request.LevelUpdateRequestDTO;
 import org.farmsystem.homepage.domain.minigame.player.dto.response.PlayerResponseDTO;
 import org.farmsystem.homepage.domain.minigame.player.entity.Player;
 import org.farmsystem.homepage.domain.minigame.player.repository.PlayerRepository;
@@ -24,22 +25,31 @@ public class PlayerService {
     private final UserRepository userRepository;
 
     //플레이어 재화 업데이트
-    public PlayerCurrencyDTO updatePlayer(Long userId, PlayerCurrencyDTO requestDTO) {
+    public PlayerCurrencyDTO updateCurrency(Long userId, PlayerCurrencyDTO requestDTO) {
         Player player = playerRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAYER_NOT_FOUND));
 
-        player.update(requestDTO.seedticket(), requestDTO.gold(), requestDTO.sunlight());
+        player.updateCurrency(requestDTO.seedTicket(), requestDTO.gold(), requestDTO.sunlight(), requestDTO.seedCount());
         return PlayerCurrencyDTO.from(player);
 
     }
 
-    //플레이어 재화 조회
-    @Transactional(readOnly = true)
-    public PlayerCurrencyDTO getPlayerCurrency(Long userId) {
+    //플레이어 레벨 업데이트
+    public PlayerResponseDTO updateLevel(Long userId, LevelUpdateRequestDTO requestDTO) {
         Player player = playerRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PLAYER_NOT_FOUND));
 
-        return PlayerCurrencyDTO.from(player);
+        player.updateLevel(requestDTO.newLevel());
+        return PlayerResponseDTO.from(player);
+    }
+
+    //플레이어 재화 조회
+    @Transactional(readOnly = true)
+    public PlayerResponseDTO getPlayerCurrency(Long userId) {
+        Player player = playerRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAYER_NOT_FOUND));
+
+        return PlayerResponseDTO.from(player);
     }
 
     @Transactional
@@ -55,7 +65,8 @@ public class PlayerService {
         try {
             Player created = playerRepository.save(Player.createPlayer(user));
             return PlayerResponseDTO.from(created);
-        } catch (DataIntegrityViolationException e) { //user UNIQUE 제약 위반 시
+        }
+        catch (DataIntegrityViolationException e) { //user UNIQUE 제약 위반 시
             //거의 동시에 다른 요청이 같은 userId로 생성 완료한 경우 대비
             Player first = playerRepository.findByUser_UserId(userId)
                     .orElseThrow(() -> e);


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #170 
 
## 🌱 작업 사항
- 플레이어 엔티티에 seedCount 필드 추가
- 플레이어 재화 업데이트 api 변경 (seedCount 추가, 요청/응답 dto의 변수명 수정)
- 플레이어 레벨 업데이트 api 추가
- 플레이어 조회 api에 유저아이디, 플레이어 아이디 제외하도록 수정

## 🌱 참고 사항

