### PR TITLE
[fix] 엔티티 생성 시 readOnly 트랜잭션으로 인한 insert 오류 수정

### DIFF
--- a/src/main/java/org/farmsystem/homepage/domain/minigame/farm/entity/PlantStatus.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/farm/entity/PlantStatus.java
@@ -5,8 +5,8 @@ import org.farmsystem.homepage.global.error.exception.BusinessException;
 
 public enum PlantStatus {
     EMPTY,
-    PLANTED,
-    READY;
+    GROWING,
+    GROWN;
 
     public static PlantStatus fromString(String status) {
         try {

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/farm/service/FarmService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/farm/service/FarmService.java
@@ -38,7 +38,7 @@ public class FarmService {
     }
 
     // 전체 텃밭(9칸) 조회 API
-    @Transactional(readOnly = true)
+    @Transactional
     public List<TileResponseDTO> getFarm(Long userId) {
 
         Player player = findPlayerOrThrow(userId);
@@ -102,7 +102,7 @@ public class FarmService {
         }
 
         // PLANTED 또는 READY로 변경 → 필수 필드 검증
-        if (newStatus == PlantStatus.PLANTED || newStatus == PlantStatus.READY) {
+        if (newStatus == PlantStatus.GROWING || newStatus == PlantStatus.GROWN) {
             if (request.plantedAt() == null || request.sunlightCount() == null) {
                 throw new BusinessException(ErrorCode.MISSING_REQUIRED_FIELD);
             }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/DailyGameService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/player/service/DailyGameService.java
@@ -32,7 +32,7 @@ public class DailyGameService {
     }
 
     // 게임의 남은 횟수 조회
-    @Transactional(readOnly = true)
+    @Transactional
     public GameCountResponseDTO getGameCount(Long userId, String gameType) {
         Player player = findPlayerOrThrow(userId);
         DailyGame dailyGame = getOrCreateDailyGame(player);

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/controller/SolarController.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/controller/SolarController.java
@@ -14,14 +14,14 @@ import org.springframework.web.bind.annotation.*;
 public class SolarController {
 
     private final SolarService solarService;
-    // 플레이어의 태양광 발전소 상태 조회
+    // 플레이어의 태양광 발전소 충전시작시간 조회
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getSolarStation(@AuthenticationPrincipal Long userId) {
         SolarDTO response = solarService.getSolarStation(userId);
         return SuccessResponse.ok(response);
     }
 
-    // 플레이어의 태양광 발전소 상태 업데이트
+    // 플레이어의 태양광 발전소 충전시작시간 업데이트
     @PatchMapping("/chargetime")
     public ResponseEntity<SuccessResponse<?>> updateChargeTime(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/dto/SolarDTO.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/dto/SolarDTO.java
@@ -7,13 +7,11 @@ import org.farmsystem.homepage.domain.minigame.solarstation.entity.SolarPowerSta
 import java.time.LocalDateTime;
 
 public record SolarDTO(
-        LocalDateTime chargeStartTime,
-        @Min(0) @Max(100) Integer level
+        LocalDateTime chargeStartTime
 ) {
     public static SolarDTO from(SolarPowerStation station) {
         return new SolarDTO(
-                station.getChargeStartedAt(),
-                station.getLevel()
+                station.getChargeStartedAt()
         );
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/entity/SolarPowerStation.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/entity/SolarPowerStation.java
@@ -18,9 +18,6 @@ public class SolarPowerStation {
     @Column(name = "station_id", nullable = false)
     private Long stationId;
 
-    @Column(name = "level", nullable = false)
-    private int level;
-
     @Column(name = "charge_started_at")
     private LocalDateTime chargeStartedAt;
 
@@ -30,24 +27,19 @@ public class SolarPowerStation {
 
     // 플레이어의 태양광 발전소를 처음 생성
     public static SolarPowerStation createSolarStation(Player player) {
-        return new SolarPowerStation(player, 0, null);
+        return new SolarPowerStation(player, null);
     }
 
-    // 발전소 상태 업데이트
-    public void updateState(LocalDateTime startedAt, Integer newLevel) {
+    // 충전 시작 시간 갱신
+    public void updateChargeStartTime(LocalDateTime startedAt) {
         if (startedAt != null) {
             this.chargeStartedAt = startedAt;
-        }
-        if (newLevel != null) {
-            int clamped = Math.max(0, Math.min(100, newLevel));
-            this.level = clamped;
         }
     }
 
     // createSolarStation으로만 생성
-    private SolarPowerStation(Player player, int level, LocalDateTime chargeStartedAt) {
+    private SolarPowerStation(Player player, LocalDateTime chargeStartedAt) {
         this.player = player;
-        this.level = level;
         this.chargeStartedAt = chargeStartedAt;
     }
 }

--- a/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/service/SolarService.java
+++ b/src/main/java/org/farmsystem/homepage/domain/minigame/solarstation/service/SolarService.java
@@ -29,7 +29,7 @@ public class SolarService {
                 .orElseGet(() -> solarRepository.save(SolarPowerStation.createSolarStation(player)));
     }
     // 플레이어의 태양광 발전소 조회
-    @Transactional(readOnly=true)
+    @Transactional
     public SolarDTO getSolarStation(Long userId) {
         Player player = findPlayerOrThrow(userId);
         SolarPowerStation station = getOrCreateStation(player);
@@ -41,7 +41,7 @@ public class SolarService {
         Player player = findPlayerOrThrow(userId);
         SolarPowerStation station = getOrCreateStation(player);
 
-        station.updateState(request.chargeStartTime(), request.level());
+        station.updateChargeStartTime(request.chargeStartTime());
 
         return SolarDTO.from(station);
     }


### PR DESCRIPTION
## 🌱 관련 이슈
- close : #175
 
## 🌱 작업 사항
- Farm, SolarStation, DailyGame 서비스 메서드에서 @Transactional(readOnly = true) 제거하여 신규 엔티티 생성 시 insert 실행 가능하도록 수정
- Dex/Badge 등 조회 전용 메서드에는 readOnly 유지
- SolarStation에서 level제거

## 🌱 참고 사항
기능을 만들 때 생긴 이슈에 대해서 다른사람들이 참고해야 할 사항을 적습니다.
